### PR TITLE
fix(ime): macOS WKWebView 한글 onData 이중배달 — defer 리듀서 수리 (v0.12.21 rebase)

### DIFF
--- a/scripts/install-ime3-build.sh
+++ b/scripts/install-ime3-build.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# IME 3차 수리 빌드 설치 — ★master 승인 게이트 뒤에만 실행 (앱 종료 상태 필수).
+# 절차: 백업 → cys-dept 동봉(2차 탈락 전례 복원) → ditto 교체 → adhoc 서명 → quarantine 제거
+#      → 계측 플래그 시딩(cysImeDebug=1) → 재기동은 주인님/master가 수동.
+set -e
+SRC="$HOME/.cys/src/cys-terminal"
+BUNDLE="$SRC/target/release/bundle/macos/cys.app"
+[ -d "$BUNDLE" ] || { echo "빌드 산출물 없음: $BUNDLE"; exit 1; }
+if pgrep -qf "cys.app/Contents/MacOS/cys-app"; then
+  echo "⚠ cys.app 실행 중 — GUI 종료 후 실행하라 (cysd 데몬은 유지 — 세션 생존)"; exit 1
+fi
+
+# 1) 현 설치본 백업 (타임스탬프)
+BK="/Applications/cys.app.backup-pre-ime3-$(date +%H%M)"
+ditto /Applications/cys.app "$BK"
+echo "백업: $BK"
+
+# 2) cys-dept 동봉 — 2차 설치 때 소리 없이 탈락한 전례 복원 (CLAUDE.md 전체경로 계약 준수)
+cp "$SRC/cysjavis-pack/bin/cys-dept" "$BUNDLE/Contents/MacOS/cys-dept"
+chmod +x "$BUNDLE/Contents/MacOS/cys-dept"
+
+# 3) 교체 + 서명 + quarantine 제거
+ditto "$BUNDLE" /Applications/cys.app
+codesign --force --deep --sign - /Applications/cys.app
+xattr -dr com.apple.quarantine /Applications/cys.app 2>/dev/null || true
+
+# 4) 계측 플래그 시딩 (다음 기동부터 $TMPDIR/cys-ime.log 기록 — 근본원인 확정 캡처용)
+sh "$SRC/scripts/seed-ime-debug.sh"
+
+# 5) 검증
+ls -la /Applications/cys.app/Contents/MacOS/
+codesign -v /Applications/cys.app && echo "서명 OK"
+echo "설치 완료 — cys.app 재기동 후 주인님 실타이핑으로 캡처·판정. 캡처 후 계측 끄기: seed-ime-debug.sh off (+재시작)"

--- a/scripts/seed-ime-debug.sh
+++ b/scripts/seed-ime-debug.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# IME 계측 플래그 시딩 — cys.app 종료 상태에서 실행 (게이트 뒤 설치 절차용).
+# WKWebView localStorage(sqlite)에 cysImeDebug=1 을 심어, 다음 기동부터 모든 pane이
+# 이벤트 시퀀스를 $TMPDIR/cys-ime.log 로 기록하게 한다 (main.ts는 pane 생성 시 플래그를 읽음).
+# 끄기: 인자로 off 전달 (키 삭제).
+set -e
+DB=$(find "$HOME/Library/WebKit/com.cysjavis.terminal" -name "localstorage.sqlite3" -path "*LocalStorage*" | head -1)
+[ -n "$DB" ] || { echo "localstorage.sqlite3 없음 — cys.app을 한 번이라도 실행한 적 있어야 함"; exit 1; }
+if pgrep -qf "cys.app/Contents/MacOS/cys-app"; then
+  echo "⚠ cys.app 실행 중 — 종료 후 실행해야 반영됨(실행 중 편집은 종료 시 덮어써짐)"; exit 1
+fi
+if [ "$1" = "off" ]; then
+  sqlite3 "$DB" "DELETE FROM ItemTable WHERE key='cysImeDebug';"
+  echo "cysImeDebug 제거 완료: $DB"
+else
+  # value는 UTF-16LE BLOB ("1" = X'3100')
+  sqlite3 "$DB" "INSERT OR REPLACE INTO ItemTable(key, value) VALUES ('cysImeDebug', X'3100');"
+  echo "cysImeDebug=1 시딩 완료: $DB"
+fi

--- a/ui/src/ime.test.ts
+++ b/ui/src/ime.test.ts
@@ -140,6 +140,38 @@ describe("keydown/blur flush · 229 무전송 · onData 순서 보존", () => {
   });
 });
 
+describe("빈 onData 유출 가드 — 조합중 홑자모 (2026-07-06 실기기 계측 회귀)", () => {
+  // 실캡처($TMPDIR/cys-ime.log · 오늘 세션): 사용자가 조합 중 홑자모까지 되돌린 상태에서
+  // 데이터 없는 onData("")가 도착 → 수정 전에는 flush("onData")가 그 자모를 완성음절 앞으로
+  // 유출(실 PTY 유출 5건: ㅇㅈㅇㅎㄱ). 수정 후에는 유출 0·유실 0.
+  it("pending 'ㅎ'(조합중) + onData('') ⇒ 전송 0, pending 'ㅎ' 유지(유출 차단)", () => {
+    const r = run([onData("")], { pending: "ㅎ" });
+    expect(r.sends).toEqual([]); // 수정 전에는 ["ㅎ"] (자모 유출)
+    expect(r.state.pending).toBe("ㅎ"); // 조합 지속 — 후속 이벤트가 흡수/완성
+    expect(r.debugs).toContain('onData(empty) keep composing jamo "ㅎ"');
+  });
+
+  it("실캡처 재생: insertReplacementText로 홑자모 복귀 후 빈 onData ⇒ 자모 미유출", () => {
+    // 로그: ...RT '하'←'합'←'하'←'ㅎ' 후 onData recv "" pending="ㅎ" → FLUSH(onData) "ㅎ"(버그)
+    const r = run([
+      input("insertReplacementText", "합"), // pending "하" → "합"  (seed pending "하")
+      input("insertReplacementText", "하"), // 재조합 "합" → "하"
+      input("insertReplacementText", "ㅎ"), // 홑자모까지 되돌림 pending "ㅎ"
+      onData(""), // 빈 onData — 유출 지점
+    ], { pending: "하" });
+    expect(r.bytes).toBe(""); // 조합중 자모는 새어나가지 않는다
+    expect(r.state.pending).toBe("ㅎ");
+  });
+
+  it("완성형 pending은 빈 onData에도 종전대로 flush(유실 방지 — 가드는 조합중 자모 한정)", () => {
+    const r = run([onData("")], { pending: "안" });
+    // 완성음절은 진짜 직전 음절 → 순서 보존 flush 유지(뒤따르는 빈 data send는 무해 no-op).
+    expect(r.bytes).toBe("안"); // 유실 0 — "안"은 PTY로 나간다
+    expect(r.sends).toContain("안");
+    expect(r.state.pending).toBe("");
+  });
+});
+
 describe("isHangulText — 자모·완성형만 참", () => {
   it("자모/완성형 참, 그 외 거짓", () => {
     expect(isHangulText("ㄴ")).toBe(true);

--- a/ui/src/ime.test.ts
+++ b/ui/src/ime.test.ts
@@ -322,3 +322,63 @@ describe("isHangulText — 자모·완성형만 참", () => {
     expect(isHangulText("")).toBe(false);
   });
 });
+
+describe("R1 리뷰 보강 회귀(2026-07-06) — 누적·역전·U+1100 초성", () => {
+  it("R1-①: 다중 onData 누적 'ㅁ'+'마' → insertText 'ㅁ' 부분취소 → RT '마' 취소 ⇒ '마' 1회", () => {
+    const r = run([
+      onDataWk("ㅁ"), // deferred "ㅁ"
+      onDataWk("마"), // deferred "ㅁ마" (누적 — 타이머 미만료 고속 입력)
+      input("insertText", "ㅁ"), // 앞부분만 받아감 → 부분취소, 잔여 "마"
+      input("insertReplacementText", "마"), // 잔여도 받아감 → 전체 취소
+      keydown(32, " "), // 경계
+    ]);
+    expect(r.bytes).toBe("마"); // 수정 전에는 "마ㅁ마"류 복제
+    expect(r.state.deferred).toBe("");
+  });
+
+  it("R1-①b: 유예 홑자모가 머신 커밋 음절의 초성이면 흡수 취소 (유예 'ㅁ' ⊂ 커밋 '마')", () => {
+    const r = run([
+      onDataWk("ㅁ"),
+      input("insertText", "마"), // 머신이 조합 완성분을 직접 커밋
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("마"); // 수정 전에는 타임아웃/경계에서 "ㅁ" 유출
+  });
+
+  it("R1-②: pending(구분) '나' + 유예(신분) '가' → keydown ⇒ '나가' (시간순 — 역전 차단)", () => {
+    const r = run([onDataWk("가"), keydown(13, "Enter")], { pending: "나" });
+    expect(r.bytes).toBe("나가"); // 수정 전에는 "가나" (유예분 선전송 역전)
+  });
+
+  it("R1-②b: 유예(구분) '가' 잔존 중 insertText '나' 신규 커밋 ⇒ '가' 먼저 방출 (가나)", () => {
+    const r = run([
+      onDataWk("가"), // 조합전용 프로필의 직전 음절 — 머신이 안 받아감
+      input("insertText", "나"), // 다음 음절 신규 커밋 (유예분보다 신분)
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("가나"); // 시간순: 가(구) → 나(신)
+    expect(r.state.deferred).toBe("");
+  });
+
+  it("R1-②c: deferTimeout도 pending(구분) 우선 — pending '나' + 유예 '가' ⇒ '나가'", () => {
+    const r = run([onDataWk("가"), deferTimeout()], { pending: "나" });
+    expect(r.bytes).toBe("나가");
+  });
+
+  it("R1-③: U+1100 조합자모 초성도 흡수 판별 — pending 'ᄆ'(U+1106) + 유예 '마' ⇒ '마'만", () => {
+    const r = run([onDataWk("마"), deferTimeout()], { pending: "ᄆ" });
+    expect(r.bytes).toBe("마"); // 수정 전에는 "마ᄆ"류 (흡수 실패 → 자모 유출)
+    expect(isChoseongOf("ᄆ", "마")).toBe(true);
+    expect(isChoseongOf("ᄂ", "마")).toBe(false); // ᄂ은 마의 초성 아님
+  });
+
+  it("기존 불변 재확인: 정상 페어링(onData 자모→insertText 동일)은 종전과 동일 경로", () => {
+    const r = run([
+      onDataWk("ㄹ"),
+      input("insertText", "ㄹ"),
+      input("insertReplacementText", "료"),
+      keydown(32, " "),
+    ], { pending: "완" });
+    expect(r.bytes).toBe("완료");
+  });
+});

--- a/ui/src/ime.test.ts
+++ b/ui/src/ime.test.ts
@@ -3,27 +3,32 @@
 // 각 프로필은 실기기 WebKit이 발화한 DOM 이벤트 순서다. 리듀서를 그 순서로 돌려
 // PTY로 나가는 바이트(sends)와 잔여 조합 상태(pending)를 검증한다.
 import { describe, it, expect } from "bun:test";
-import { imeStep, initialImeState, isHangulText, type ImeEvent, type ImeState } from "./ime";
+import { imeStep, initialImeState, isHangulText, isChoseongOf, type ImeEvent, type ImeState } from "./ime";
 
-/** 이벤트 시퀀스를 리듀서에 흘려 전송 바이트·debug·최종 state를 수집한다. */
-function run(events: ImeEvent[], start: ImeState = initialImeState()) {
-  let state = start;
+/** 이벤트 시퀀스를 리듀서에 흘려 전송 바이트·debug·armDefer 횟수·최종 state를 수집한다. */
+function run(events: ImeEvent[], start?: Partial<ImeState>) {
+  let state: ImeState = { ...initialImeState(), ...start };
   const sends: string[] = [];
   const debugs: string[] = [];
+  let armDefers = 0;
   for (const ev of events) {
     const r = imeStep(state, ev);
     state = r.state;
     for (const a of r.actions) {
       if ("send" in a) sends.push(a.send);
+      else if ("armDefer" in a) armDefers++;
       else debugs.push(a.debug);
     }
   }
-  return { state, sends, debugs, bytes: sends.join("") };
+  return { state, sends, debugs, armDefers, bytes: sends.join("") };
 }
 
 const input = (inputType: string, data: string | null): ImeEvent => ({ kind: "input", inputType, data });
 const keydown = (keyCode: number, key: string): ImeEvent => ({ kind: "keydown", keyCode, key });
 const onData = (data: string): ImeEvent => ({ kind: "onData", data });
+/** macOS WKWebView 배선의 onData(wk=true) — 한글 defer 경로 활성. */
+const onDataWk = (data: string): ImeEvent => ({ kind: "onData", data, wk: true });
+const deferTimeout = (): ImeEvent => ({ kind: "deferTimeout" });
 
 describe("Profile C — 혼성(신규 버그): insertText 자모 커밋 후 표준 composition 진행", () => {
   it("insertText 'ㄴ' → compositionstart → onData '너' ⇒ 정확히 '너'만 전송(자모 유출 없음)", () => {
@@ -169,6 +174,141 @@ describe("빈 onData 유출 가드 — 조합중 홑자모 (2026-07-06 실기기
     expect(r.bytes).toBe("안"); // 유실 0 — "안"은 PTY로 나간다
     expect(r.sends).toContain("안");
     expect(r.state.pending).toBe("");
+  });
+});
+
+describe("3차 재발(2026-07-06) — 이중배달 defer 회귀: 초성 선유출·음절 복제", () => {
+  // 주인님 실증 샘플(master pane 실타이핑): "ㅁ마스터다"·"ㅎ화"·"ㄷ되"(패턴 A 초성 선유출),
+  // "다다"·"해해"(패턴 B 음절 복제). 0.12.20 업스트림 리듀서 재작성 때 1차 defer(017e20e)가
+  // 소실되어 onData 즉시 send가 부활한 것 — 아래 시퀀스는 수리 전 리듀서에서 샘플과 동일한
+  // 바이트열을 재생함을 확인했다(패턴A: "ㅁ"+"마"+DEL"마"→화면 "ㅁ마" · 패턴B: "다다").
+  it("패턴 A: insertText 'ㅁ' → onData '마' → RT '마' ⇒ '마'만 (초성 선유출 차단)", () => {
+    const r = run([
+      input("insertText", "ㅁ"), // 머신이 초성 커밋 → pending "ㅁ"
+      onDataWk("마"), // xterm 이중배달(완성 음절) — 수리 전: flush가 "ㅁ" 유출 + "마" 즉시 send
+      input("insertReplacementText", "마"), // 머신이 같은 글자를 받아감 → 유예분 취소
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("마"); // 수리 전: "ㅁ마\x7f마" (화면 "ㅁ마")
+    expect(r.state.deferred).toBe("");
+    expect(r.debugs).toContain('DEFER-cancel(insertReplacementText) "마"');
+  });
+
+  it("패턴 A 키마다 이중배달(1차 프로필): onData 'ㅁ'→insertText 'ㅁ'→onData '마'→RT '마' ⇒ '마'만", () => {
+    const r = run([
+      onDataWk("ㅁ"), // xterm이 조합 시작 자모도 배달 — 수리 전: 즉시 send(자모 유출)
+      input("insertText", "ㅁ"), // 머신이 받아감 → 유예 취소, pending "ㅁ"
+      onDataWk("마"),
+      input("insertReplacementText", "마"),
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("마"); // 수리 전: "ㅁㅁ마\x7f마"
+    expect(r.debugs).toContain('DEFER-cancel(insertText) "ㅁ"');
+  });
+
+  it("패턴 B: insertText 'ㄷ' → RT '다' → onData '다' ⇒ '다'만 (음절 복제 차단)", () => {
+    const r = run([
+      input("insertText", "ㄷ"),
+      input("insertReplacementText", "다"), // pending "다"
+      onDataWk("다"), // xterm 이중배달 — 수리 전: flush "다" + send "다" = "다다"
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("다"); // 수리 전: "다다"
+    expect(r.debugs).toContain('DUP-drop(onData) "다" (== pending)');
+  });
+
+  it("실증 샘플 재생: '너는' 어절 — 이중배달 혼입에도 '너는' 정확 출력", () => {
+    // 너(ㄴ+ㅓ) 는(ㄴ+ㅡ+ㄴ): 머신 체인 + 간헐 onData 이중배달 혼입 시퀀스
+    const r = run([
+      input("insertText", "ㄴ"), // pending "ㄴ"
+      onDataWk("너"), // 이중배달
+      input("insertReplacementText", "너"), // 취소·pending "너"
+      input("insertText", "ㄴ"), // 다음 음절 초성 → flush "너", pending "ㄴ"
+      input("insertReplacementText", "느"), // pending "느"
+      onDataWk("는"), // 이중배달(완성)
+      input("insertReplacementText", "는"), // 취소·pending "는"
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("너는"); // 수리 전: "너너는..." 류 복제/유출
+  });
+});
+
+describe("defer 타임아웃 — 머신 미작동 변종(insertFromComposition만) 유실 0", () => {
+  it("onData '히'(wk) → 타임아웃 ⇒ '히' 전송 (차단이 아닌 유예 — 유실 0)", () => {
+    const r = run([onDataWk("히"), deferTimeout()]);
+    expect(r.bytes).toBe("히");
+    expect(r.armDefers).toBe(1); // 배선에 타이머 장전 지시
+    expect(r.state.deferred).toBe("");
+  });
+
+  it("취소된 유예분은 타임아웃에 전송 없음 (복제 0)", () => {
+    const r = run([onDataWk("ㅁ"), input("insertText", "ㅁ"), deferTimeout(), keydown(13, "Enter")]);
+    expect(r.bytes).toBe("ㅁ"); // Enter가 pending "ㅁ" flush — 유예분 복제 없음
+  });
+
+  it("타임아웃 시 pending 초성이 유예 음절에 흡수된 상태면 폐기 (유출 0)", () => {
+    // 머신이 insertText까지만 발화하고 멈춘 변종: pending "ㅁ" + deferred "마"
+    const r = run([input("insertText", "ㅁ"), onDataWk("마"), deferTimeout()]);
+    expect(r.bytes).toBe("마"); // "ㅁ마" 아님 — 초성은 그 음절의 조합중 상태
+    expect(r.state.pending).toBe("");
+    expect(r.debugs).toContain('DROP(absorbed-by-deferred) "ㅁ"');
+  });
+
+  it("keydown(Enter)이 타임아웃보다 먼저 와도 경계 유출 없음", () => {
+    const r = run([input("insertText", "ㅁ"), onDataWk("마"), keydown(13, "Enter")]);
+    expect(r.bytes).toBe("마"); // releaseDeferred(keydown)가 흡수 해소 후 방출
+  });
+
+  it("비한글 onData는 유예분 먼저 방출 후 데이터 전송 (순서 보존)", () => {
+    const r = run([onDataWk("가"), onDataWk("\r")]);
+    expect(r.sends).toEqual(["가", "\r"]);
+  });
+});
+
+describe("wk 프로필 재생 — 기존 프로필 A·C의 defer 경로 등가", () => {
+  it("Profile C(wk): insertText 'ㄴ' → compositionstart → onData '너' → 타임아웃 ⇒ '너'", () => {
+    const r = run([
+      input("insertText", "ㄴ"),
+      { kind: "compositionstart" },
+      onDataWk("너"),
+      deferTimeout(),
+    ]);
+    expect(r.bytes).toBe("너");
+    expect(r.state.pending).toBe("");
+  });
+
+  it("Profile A(wk): composition 3종 → onData '한' → 타임아웃 ⇒ '한' 1회", () => {
+    const r = run([
+      { kind: "compositionstart" },
+      { kind: "compositionupdate" },
+      { kind: "compositionend" },
+      onDataWk("한"),
+      deferTimeout(),
+    ]);
+    expect(r.sends).toEqual(["한"]);
+  });
+
+  it("영문·비한글(wk)은 유예 없이 즉시 전송 (지연 0·회귀 0)", () => {
+    const r = run([onDataWk("a"), onDataWk("1")]);
+    expect(r.sends).toEqual(["a", "1"]);
+    expect(r.armDefers).toBe(0);
+  });
+
+  it("비wk 배선(Windows WebView2)은 한글 onData도 종전 즉시 send (회귀 0)", () => {
+    const r = run([onData("너")]);
+    expect(r.sends).toEqual(["너"]);
+    expect(r.armDefers).toBe(0);
+  });
+});
+
+describe("isChoseongOf — 초성 흡수 판별", () => {
+  it("초성 매칭만 참", () => {
+    expect(isChoseongOf("ㅁ", "마")).toBe(true);
+    expect(isChoseongOf("ㅎ", "화")).toBe(true);
+    expect(isChoseongOf("ㄴ", "마")).toBe(false);
+    expect(isChoseongOf("ㅁㅁ", "마")).toBe(false);
+    expect(isChoseongOf("ㅁ", "")).toBe(false);
+    expect(isChoseongOf("ㅁ", "m")).toBe(false);
   });
 });
 

--- a/ui/src/ime.test.ts
+++ b/ui/src/ime.test.ts
@@ -233,7 +233,7 @@ describe("3차 재발(2026-07-06) — 이중배달 defer 회귀: 초성 선유�
   });
 });
 
-describe("defer 타임아웃 — 머신 미작동 변종(insertFromComposition만) 유실 0", () => {
+describe("defer 타임아웃 — onData 도착 계약: 머신이 안 받아간 유예분은 타임아웃 전송(유실 0)", () => {
   it("onData '히'(wk) → 타임아웃 ⇒ '히' 전송 (차단이 아닌 유예 — 유실 0)", () => {
     const r = run([onDataWk("히"), deferTimeout()]);
     expect(r.bytes).toBe("히");
@@ -380,5 +380,37 @@ describe("R1 리뷰 보강 회귀(2026-07-06) — 누적·역전·U+1100 초성"
       keydown(32, " "),
     ], { pending: "완" });
     expect(r.bytes).toBe("완료");
+  });
+});
+
+describe("R2 리뷰 보강 회귀(2026-07-06) — inverse-prefix: 병합 커밋이 유예분을 포함", () => {
+  it("R2-①: onData '마' → insertText '마스'(병합) ⇒ '마스' (유예분 subsumed 취소 — 마마스 차단)", () => {
+    const r = run([
+      onDataWk("마"),
+      input("insertText", "마스"),
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("마스"); // 수정 전에는 "마마스" (stale 방출 + multi-head 중복)
+    expect(r.state.deferred).toBe("");
+  });
+
+  it("R2-①b: onData '마' → insertText '마스터'(3음절 병합) ⇒ '마스터'", () => {
+    const r = run([
+      onDataWk("마"),
+      input("insertText", "마스터"),
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("마스터"); // 수정 전에는 "마마스터"
+  });
+
+  it("R2-①c: replacement 경로 — insertText 'ㅁ' → onData '마' → RT '마스' ⇒ '마스' (마스마 차단)", () => {
+    const r = run([
+      input("insertText", "ㅁ"),
+      onDataWk("마"),
+      input("insertReplacementText", "마스"),
+      keydown(13, "Enter"),
+    ]);
+    expect(r.bytes).toBe("마스"); // 수정 전에는 "마스마" (RT 무취소 → 경계에서 유예분 후행 방출)
+    expect(r.state.deferred).toBe("");
   });
 });

--- a/ui/src/ime.ts
+++ b/ui/src/ime.ts
@@ -18,8 +18,9 @@ export interface ImeState {
    * (insertText→insertReplacementText) 두 경로가 같은 글자를 모두 배달한다. 0.12.20 업스트림
    * 리듀서 재작성 때 1차 수리(defer)가 소실되어 onData 즉시 send가 부활 — 초성 선유출
    * ("ㅁ마")·음절 복제("다다")가 재발했다. 한글 onData는 여기 buffered 후 DEFER_MS 유예:
-   * 같은 글자를 input 머신이 받아가면(exact match) 취소, 아무도 안 받아가면 타임아웃 전송
-   * (insertFromComposition만 쓰는 WebKit 변종 유실 0 — 차단이 아닌 유예).
+   * input 머신이 받아가면 취소(동일=전체·앞부분=부분·초성흡수=전체), 아무도 안 받아가면
+   * 타임아웃 전송(insertFromComposition만 쓰는 WebKit 변종 유실 0 — 차단이 아닌 유예).
+   * 방출 시 pending(구분)이 유예분보다 먼저 나간다(시간순 보존).
    */
   deferred: string;
 }
@@ -60,14 +61,19 @@ export const isHangulText = (t: string) => HANGUL_TEXT.test(t);
 const INCOMPLETE_JAMO = /^[ㄱ-ㆎᄀ-ᇿ]+$/;
 export const isIncompleteJamo = (t: string) => INCOMPLETE_JAMO.test(t);
 
-// 완성형 음절의 초성(호환자모) — pending 홑자모가 deferred 첫 음절의 조합중 초성인지 판별용.
-// (예: pending "ㅁ"은 deferred "마"의 초성 → 그 음절에 흡수된 조합중 상태이므로 별도 전송 금지)
+// 완성형 음절의 초성 — pending/deferred 홑자모가 어느 음절의 조합중 초성인지 판별용.
+// (예: "ㅁ"은 "마"의 초성 → 그 음절에 흡수된 조합중 상태이므로 별도 전송 금지)
+// 호환자모(ㄱ-ㅎ)와 조합자모 초성(U+1100-1112) 둘 다 판별한다 — U+1100 범위는 완성형
+// 초성 인덱스와 동일 순서라 직접 대조(리뷰 R1: 호환자모 한정이라 "마ᄆ" 흡수 실패하던 갭).
 const CHOSEONG = ["ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"];
 export const isChoseongOf = (jamo: string, syllable: string) => {
   if (jamo.length !== 1 || !syllable) return false;
   const c = syllable.codePointAt(0)! - 0xac00;
   if (c < 0 || c > 11171) return false;
-  return CHOSEONG[Math.floor(c / 588)] === jamo;
+  const li = Math.floor(c / 588);
+  const j = jamo.codePointAt(0)!;
+  if (j >= 0x1100 && j <= 0x1112) return j - 0x1100 === li;
+  return CHOSEONG[li] === jamo;
 };
 
 export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
@@ -82,17 +88,29 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
       pending = "";
     }
   };
-  // input 머신이 같은 글자를 받아갔다 — 유예분 취소(이중배달 차단). exact match 한정:
-  // 과잉 취소(≠)는 유실, 과소 취소는 40ms 뒤 복제이므로, 이중배달 프로필이 두 경로에
-  // 문자열을 동일하게 배달한다는 1차 실측 불변식에 정확히 맞춘다.
+  // input 머신이 이 글자를 받아갔다 — 유예분 취소(이중배달 차단). 기본은 exact match
+  // (1차 실측 불변식: 두 경로가 같은 문자열을 배달)이나, 리뷰 R1 보강 2건:
+  // ①다중 onData 누적(예: "ㅁ"+"마"="ㅁ마") 중 앞쪽만 받아가면 그만큼만 부분 취소
+  // ②유예 홑자모가 머신 커밋 음절의 초성이면(예: 유예 "ㅁ" ⊂ 커밋 "마") 흡수 — 전체 취소.
+  // 과잉 취소는 유실, 과소 취소는 40ms 뒤 복제 — 받아간 만큼만 정확히 지운다.
   const cancelDeferredIfTaken = (data: string, why: string) => {
-    if (deferred && deferred === data) {
+    if (!deferred || !data) return;
+    if (deferred === data) {
       actions.push({ debug: `DEFER-cancel(${why}) "${deferred}"` });
+      deferred = "";
+    } else if (deferred.startsWith(data)) {
+      actions.push({ debug: `DEFER-cancel-partial(${why}) "${data}" 잔여 "${deferred.slice(data.length)}"` });
+      deferred = deferred.slice(data.length);
+    } else if (isChoseongOf(deferred, data)) {
+      actions.push({ debug: `DEFER-cancel-absorbed(${why}) "${deferred}" ⊂ "${data}"` });
       deferred = "";
     }
   };
-  // 유예분 방출 — pending이 그 첫 음절의 조합중 초성이면 흡수된 상태이므로 폐기(유출 금지),
-  // pending이 유예분과 동일하면 이중배달이므로 한쪽만 전송.
+  // 유예분 방출 — pending과의 관계를 해소한 뒤 시간순으로 내보낸다:
+  // ①pending == deferred → 이중배달, 한쪽만 전송 ②pending이 deferred 첫 음절의 조합중
+  // 초성 → 흡수된 상태이므로 폐기(유출 금지) ③그 외 pending은 유예분보다 먼저 커밋된
+  // 구분(舊分) → 먼저 flush해 시간순 보존(리뷰 R1: 유예분 선전송이 "나"+"가"를 "가나"로
+  // 뒤집던 역전 수정).
   const releaseDeferred = (why: string) => {
     if (!deferred) return;
     if (pending && pending === deferred) {
@@ -101,6 +119,8 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
     } else if (pending && isChoseongOf(pending, deferred)) {
       actions.push({ debug: `DROP(absorbed-by-deferred) "${pending}"` });
       pending = "";
+    } else if (pending) {
+      flush(`${why}·pending-first`);
     }
     actions.push({ debug: `DEFER-send(${why}) "${deferred}"` });
     actions.push({ send: deferred });
@@ -124,8 +144,14 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
         // 표준 composition inputType 관측 → 조합이 pending 자모를 흡수했다 → drop.
         dropSuperseded();
       } else if (inputType === "insertText" && data && isHangulText(data)) {
-        // ★머신이 이 글자를 받아간다 — onData가 유예해 둔 동일 글자를 취소(이중배달 차단).
+        // ★머신이 이 글자를 받아간다 — onData가 유예해 둔 동일/포함 글자를 취소(이중배달 차단).
+        const deferredBefore = deferred;
         cancelDeferredIfTaken(data, "insertText");
+        // 취소가 전혀 안 맞았을 때만: 남은 유예분 = 머신이 받아가지 않은 구(舊) 확정분
+        // (조합전용 프로필의 직전 음절) — 새 커밋을 pending에 앉히기 전에 방출해 시간순 보존
+        // (리뷰 R1 역전: "가" 유예 후 "나" 커밋 = "가나"). 부분 취소가 일어난 잔여분은 반대로
+        // 머신이 소비 중인 누적 스트림(신분)이므로 방출하지 않는다 — 후속 취소/타임아웃이 처리.
+        if (deferred && deferred === deferredBefore) releaseDeferred("insertText·stale");
         // 직전 조합 확정 후 새 커밋을 '수정 가능 창'(pending)에 둔다. 병합 커밋(2음절+)은
         // 마지막 음절만 수정 창에 — 앞 음절들은 확정분이므로 즉시 전송.
         flush("insertText");

--- a/ui/src/ime.ts
+++ b/ui/src/ime.ts
@@ -18,9 +18,11 @@ export interface ImeState {
    * (insertText→insertReplacementText) 두 경로가 같은 글자를 모두 배달한다. 0.12.20 업스트림
    * 리듀서 재작성 때 1차 수리(defer)가 소실되어 onData 즉시 send가 부활 — 초성 선유출
    * ("ㅁ마")·음절 복제("다다")가 재발했다. 한글 onData는 여기 buffered 후 DEFER_MS 유예:
-   * input 머신이 받아가면 취소(동일=전체·앞부분=부분·초성흡수=전체), 아무도 안 받아가면
-   * 타임아웃 전송(insertFromComposition만 쓰는 WebKit 변종 유실 0 — 차단이 아닌 유예).
-   * 방출 시 pending(구분)이 유예분보다 먼저 나간다(시간순 보존).
+   * input 머신이 받아가면 취소(containment 양방향 4분기 — cancelDeferredIfTaken), 아무도
+   * 안 받아가면 타임아웃 전송. ★onData 도착 계약: 실측 전 프로필에서 composition 확정분은
+   * onData로 별도 도착한다 — 그래서 composition inputType에서 직접 send하지 않아도 유예
+   * 타임아웃이 유실 0을 보장한다(차단이 아닌 유예). 방출 시 pending(구분)이 유예분보다
+   * 먼저 나간다(시간순 보존).
    */
   deferred: string;
 }
@@ -89,9 +91,13 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
     }
   };
   // input 머신이 이 글자를 받아갔다 — 유예분 취소(이중배달 차단). 기본은 exact match
-  // (1차 실측 불변식: 두 경로가 같은 문자열을 배달)이나, 리뷰 R1 보강 2건:
-  // ①다중 onData 누적(예: "ㅁ"+"마"="ㅁ마") 중 앞쪽만 받아가면 그만큼만 부분 취소
-  // ②유예 홑자모가 머신 커밋 음절의 초성이면(예: 유예 "ㅁ" ⊂ 커밋 "마") 흡수 — 전체 취소.
+  // (1차 실측 불변식: 두 경로가 같은 문자열을 배달)이나, 리뷰 R1·R2 보강 — containment
+  // 양방향 4분기(순서 고정):
+  // ①동일 → 전체 취소 ②deferred가 data로 시작(다중 onData 누적 "ㅁ마" 중 "ㅁ"만 받아감)
+  //   → 받아간 만큼 부분 취소 ③data가 deferred로 시작(머신이 유예분을 포함한 병합 커밋
+  //   "마스"·R2 inverse-prefix — 유예분은 그 병합분에 소비됨) → 전체 취소(전송은 머신
+  //   경로의 multi-head/pending이 담당 — 여기서 중복 head 송신 차단) ④유예 홑자모가 커밋
+  //   음절의 초성(유예 "ㅁ" ⊂ 커밋 "마") → 흡수·전체 취소.
   // 과잉 취소는 유실, 과소 취소는 40ms 뒤 복제 — 받아간 만큼만 정확히 지운다.
   const cancelDeferredIfTaken = (data: string, why: string) => {
     if (!deferred || !data) return;
@@ -101,6 +107,9 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
     } else if (deferred.startsWith(data)) {
       actions.push({ debug: `DEFER-cancel-partial(${why}) "${data}" 잔여 "${deferred.slice(data.length)}"` });
       deferred = deferred.slice(data.length);
+    } else if (data.startsWith(deferred)) {
+      actions.push({ debug: `DEFER-cancel-subsumed(${why}) "${deferred}" ⊂ merged "${data}"` });
+      deferred = "";
     } else if (isChoseongOf(deferred, data)) {
       actions.push({ debug: `DEFER-cancel-absorbed(${why}) "${deferred}" ⊂ "${data}"` });
       deferred = "";
@@ -235,7 +244,8 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
     }
     case "deferTimeout": {
       // DEFER_MS 동안 아무 input 머신 이벤트도 이 글자를 받아가지 않았다 —
-      // insertFromComposition만 쓰는 WebKit 변종(머신 미작동)이므로 유예분을 그대로 전송.
+      // 머신이 받아가지 않은 확정분(onData 도착 계약 — composition inputType은 직접 send하지
+      // 않고 onData가 나른다)이므로 유예분을 그대로 전송한다(유실 0).
       releaseDeferred("timeout");
       break;
     }

--- a/ui/src/ime.ts
+++ b/ui/src/ime.ts
@@ -38,6 +38,12 @@ export const initialImeState = (): ImeState => ({ pending: "" });
 const HANGUL_TEXT = /^[ㄱ-ㆎᄀ-ᇿ가-힣]+$/;
 export const isHangulText = (t: string) => HANGUL_TEXT.test(t);
 
+// 조합 중 자모만(호환자모 ㄱ-ㆎ·조합자모 ᄀ-ᇿ) — 완성형 음절(가-힣)은 제외.
+// 빈 onData가 도착했을 때 pending이 '아직 조합 중인 자모'인지 판별해, 완성음절 앞으로
+// 유출시키지 않고 조합 지속으로 두기 위한 기준.
+const INCOMPLETE_JAMO = /^[ㄱ-ㆎᄀ-ᇿ]+$/;
+export const isIncompleteJamo = (t: string) => INCOMPLETE_JAMO.test(t);
+
 export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
   const actions: ImeAction[] = [];
   let pending = state.pending;
@@ -111,6 +117,16 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
       break;
     }
     case "onData": {
+      // ★빈 onData 유출 가드 (2026-07-06 실기기 계측 확정): 사용자가 조합 중 홑자모까지
+      // 되돌린 상태(pending='ㅎ' 등)에서 데이터 없는 onData("")가 도착하면, 아래 flush가 그
+      // 조합중 자모를 완성음절 앞으로 유출시킨다(실 PTY 유출 5건: ㅇㅈㅇㅎㄱ). 빈 onData는
+      // 완성분을 나르지 않으므로 조합중 자모는 flush하지 않고 pending에 그대로 둔다 — 후속
+      // 조합/input 이벤트가 흡수(drop)하거나 완성 커밋한다(유출0·유실0). 완성형 pending(가-힣)은
+      // 진짜 직전 음절이므로 종전대로 flush(순서 보존).
+      if (event.data === "" && isIncompleteJamo(pending)) {
+        actions.push({ debug: `onData(empty) keep composing jamo "${pending}"` });
+        break;
+      }
       // (no-op 안전장치: 잔여 pending 있으면 순서 보존 후 전송) 뒤이어 완성 음절을 그대로 PTY로.
       flush("onData");
       actions.push({ send: event.data });

--- a/ui/src/ime.ts
+++ b/ui/src/ime.ts
@@ -12,6 +12,16 @@
 export interface ImeState {
   /** 조합 중이라 아직 확정 전송하지 않은 한글 음절(들). 보통 1글자, 병합/치환 시 다중. */
   pending: string;
+  /**
+   * ★유예(defer) 버퍼 (2026-07-06 3차 재발 수리 — 017e20e defer의 리듀서 이식):
+   * WKWebView 이중배달 프로필은 한글 키마다 xterm onData(자모/완성음절)와 input 머신
+   * (insertText→insertReplacementText) 두 경로가 같은 글자를 모두 배달한다. 0.12.20 업스트림
+   * 리듀서 재작성 때 1차 수리(defer)가 소실되어 onData 즉시 send가 부활 — 초성 선유출
+   * ("ㅁ마")·음절 복제("다다")가 재발했다. 한글 onData는 여기 buffered 후 DEFER_MS 유예:
+   * 같은 글자를 input 머신이 받아가면(exact match) 취소, 아무도 안 받아가면 타임아웃 전송
+   * (insertFromComposition만 쓰는 WebKit 변종 유실 0 — 차단이 아닌 유예).
+   */
+  deferred: string;
 }
 
 export type ImeEvent =
@@ -20,18 +30,24 @@ export type ImeEvent =
   | { kind: "compositionstart" }
   | { kind: "compositionupdate" }
   | { kind: "compositionend" }
-  | { kind: "onData"; data: string }
+  /** wk=true(macOS WKWebView 배선)일 때만 한글 defer 경로 활성 — Windows WebView2 등은 종전 즉시 send. */
+  | { kind: "onData"; data: string; wk?: boolean }
+  /** 배선의 DEFER_MS 타이머 만료 — deferred 잔여분을 전송(머신이 안 받아간 경우). */
+  | { kind: "deferTimeout" }
   | { kind: "blur" };
 
-/** send=PTY로 보낼 바이트, debug=cysImeDebug 채널 로그(평시 미출력). */
-export type ImeAction = { send: string } | { debug: string };
+/** send=PTY로 보낼 바이트, debug=cysImeDebug 채널 로그(평시 미출력), armDefer=배선에 유예 타이머 (재)장전 지시. */
+export type ImeAction = { send: string } | { debug: string } | { armDefer: true };
 
 export interface ImeResult {
   state: ImeState;
   actions: ImeAction[];
 }
 
-export const initialImeState = (): ImeState => ({ pending: "" });
+export const initialImeState = (): ImeState => ({ pending: "", deferred: "" });
+
+/** 한글 onData 유예 시간(ms) — 이중배달 프로필에서 input 머신 이벤트는 같은 tick에 도착한다(1차 실측). */
+export const DEFER_MS = 40;
 
 // 자모(31xx·11xx) + 완성형 음절(AC00-D7A3) — 멀티문자 허용: 고속 입력에서 IME가 여러 음절을
 // 한 insertText로 병합 커밋하므로 단일 문자만 인정하면 그 묶음이 통째로 유실된다.
@@ -44,9 +60,20 @@ export const isHangulText = (t: string) => HANGUL_TEXT.test(t);
 const INCOMPLETE_JAMO = /^[ㄱ-ㆎᄀ-ᇿ]+$/;
 export const isIncompleteJamo = (t: string) => INCOMPLETE_JAMO.test(t);
 
+// 완성형 음절의 초성(호환자모) — pending 홑자모가 deferred 첫 음절의 조합중 초성인지 판별용.
+// (예: pending "ㅁ"은 deferred "마"의 초성 → 그 음절에 흡수된 조합중 상태이므로 별도 전송 금지)
+const CHOSEONG = ["ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ", "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"];
+export const isChoseongOf = (jamo: string, syllable: string) => {
+  if (jamo.length !== 1 || !syllable) return false;
+  const c = syllable.codePointAt(0)! - 0xac00;
+  if (c < 0 || c > 11171) return false;
+  return CHOSEONG[Math.floor(c / 588)] === jamo;
+};
+
 export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
   const actions: ImeAction[] = [];
   let pending = state.pending;
+  let deferred = state.deferred;
 
   const flush = (why: string) => {
     if (pending) {
@@ -54,6 +81,30 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
       actions.push({ send: pending });
       pending = "";
     }
+  };
+  // input 머신이 같은 글자를 받아갔다 — 유예분 취소(이중배달 차단). exact match 한정:
+  // 과잉 취소(≠)는 유실, 과소 취소는 40ms 뒤 복제이므로, 이중배달 프로필이 두 경로에
+  // 문자열을 동일하게 배달한다는 1차 실측 불변식에 정확히 맞춘다.
+  const cancelDeferredIfTaken = (data: string, why: string) => {
+    if (deferred && deferred === data) {
+      actions.push({ debug: `DEFER-cancel(${why}) "${deferred}"` });
+      deferred = "";
+    }
+  };
+  // 유예분 방출 — pending이 그 첫 음절의 조합중 초성이면 흡수된 상태이므로 폐기(유출 금지),
+  // pending이 유예분과 동일하면 이중배달이므로 한쪽만 전송.
+  const releaseDeferred = (why: string) => {
+    if (!deferred) return;
+    if (pending && pending === deferred) {
+      actions.push({ debug: `DEFER-dedup(${why}) "${pending}"` });
+      pending = "";
+    } else if (pending && isChoseongOf(pending, deferred)) {
+      actions.push({ debug: `DROP(absorbed-by-deferred) "${pending}"` });
+      pending = "";
+    }
+    actions.push({ debug: `DEFER-send(${why}) "${deferred}"` });
+    actions.push({ send: deferred });
+    deferred = "";
   };
   // 프로필 불변 규칙: 조합 이벤트가 관측되는 순간, pending 자모는 정의상 그 조합에 흡수된
   // 것이므로 폐기(drop)한다 — flush 금지. 어떤 WebKit 프로필에서도 조합 이벤트 후 pending
@@ -73,6 +124,8 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
         // 표준 composition inputType 관측 → 조합이 pending 자모를 흡수했다 → drop.
         dropSuperseded();
       } else if (inputType === "insertText" && data && isHangulText(data)) {
+        // ★머신이 이 글자를 받아간다 — onData가 유예해 둔 동일 글자를 취소(이중배달 차단).
+        cancelDeferredIfTaken(data, "insertText");
         // 직전 조합 확정 후 새 커밋을 '수정 가능 창'(pending)에 둔다. 병합 커밋(2음절+)은
         // 마지막 음절만 수정 창에 — 앞 음절들은 확정분이므로 즉시 전송.
         flush("insertText");
@@ -82,6 +135,7 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
         }
         pending = data.slice(-1);
       } else if (inputType === "insertReplacementText" && data) {
+        cancelDeferredIfTaken(data, "insertReplacementText"); // 조합 계속 — 머신 소유(이중배달 차단)
         if (pending) {
           pending = data; // 조합 갱신 (하→한)
         } else {
@@ -97,9 +151,12 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
       break;
     }
     case "keydown": {
-      // 일반 키(Enter·Space·화살표 등, IME 처리중 229 제외) 직전에 조합 확정
+      // 일반 키(Enter·Space·화살표 등, IME 처리중 229 제외) 직전에 조합 확정.
+      // 유예분이 남아 있으면(머신이 안 받아간 onData) 먼저 방출 — releaseDeferred가
+      // pending과의 중복(dedup)·흡수(초성) 관계를 해소해 경계 유출·복제를 막는다.
       if (event.keyCode !== 229) {
         actions.push({ debug: `keydown ${event.key}` });
+        releaseDeferred("keydown");
         flush("keydown");
       }
       break;
@@ -122,21 +179,46 @@ export function imeStep(state: ImeState, event: ImeEvent): ImeResult {
       // 조합중 자모를 완성음절 앞으로 유출시킨다(실 PTY 유출 5건: ㅇㅈㅇㅎㄱ). 빈 onData는
       // 완성분을 나르지 않으므로 조합중 자모는 flush하지 않고 pending에 그대로 둔다 — 후속
       // 조합/input 이벤트가 흡수(drop)하거나 완성 커밋한다(유출0·유실0). 완성형 pending(가-힣)은
-      // 진짜 직전 음절이므로 종전대로 flush(순서 보존).
+      // 진짜 직전 음절이므로 종전대로 flush(순서 보존). 유예분(deferred)도 건드리지 않는다 —
+      // 빈 onData는 아무것도 나르지 않으므로 순서 제약이 없고, 조기 방출은 복제를 만든다.
       if (event.data === "" && isIncompleteJamo(pending)) {
         actions.push({ debug: `onData(empty) keep composing jamo "${pending}"` });
         break;
       }
+      // ★한글 onData 유예 (3차 재발 수리 — 017e20e defer의 리듀서 이식, wk 배선 한정):
+      // 이중배달 프로필은 같은 글자를 input 머신이 같은 tick에 받아간다(1차 실측) — 즉시
+      // send하면 pending flush와 겹쳐 초성 선유출("ㅁ마")·음절 복제("다다")가 된다. 유예 후
+      // 머신이 받아가면 취소(cancelDeferredIfTaken), 안 받아가면 타임아웃 전송(유실 0).
+      if (event.wk && event.data && isHangulText(event.data)) {
+        if (event.data === pending) {
+          // 머신이 이미 이 글자를 조합 창(pending)에 소유 — onData 쪽은 이중배달분이므로 폐기.
+          actions.push({ debug: `DUP-drop(onData) "${event.data}" (== pending)` });
+          break;
+        }
+        deferred += event.data;
+        actions.push({ debug: `DEFER(onData) "${event.data}" buffered="${deferred}"` });
+        actions.push({ armDefer: true });
+        break;
+      }
+      // 비한글(또는 비wk 배선): 순서 보존 — 유예분 → pending → 이번 데이터 순으로 전송.
+      releaseDeferred("onData-nonhangul");
       // (no-op 안전장치: 잔여 pending 있으면 순서 보존 후 전송) 뒤이어 완성 음절을 그대로 PTY로.
       flush("onData");
       actions.push({ send: event.data });
       break;
     }
+    case "deferTimeout": {
+      // DEFER_MS 동안 아무 input 머신 이벤트도 이 글자를 받아가지 않았다 —
+      // insertFromComposition만 쓰는 WebKit 변종(머신 미작동)이므로 유예분을 그대로 전송.
+      releaseDeferred("timeout");
+      break;
+    }
     case "blur": {
+      releaseDeferred("blur");
       flush("blur");
       break;
     }
   }
 
-  return { state: { pending }, actions };
+  return { state: { pending, deferred }, actions };
 }

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -4,7 +4,7 @@
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
-import { imeStep, initialImeState, type ImeEvent } from "./ime";
+import { imeStep, initialImeState, DEFER_MS, type ImeEvent } from "./ime";
 import { shellQuote, shellQuoteJoin } from "./shellquote";
 import { DEFAULT_BG, readableForeground } from "./theme";
 import { reorderWorkspace, reorderGroup } from "./reorder";
@@ -1610,29 +1610,41 @@ async function makePane(sid: number, title: string, socket?: string): Promise<Pa
   const dbg = (line: string) => {
     if (imeDbg) invoke("log_ime", { line: `[s${sid}] ${line}` }).catch(() => {});
   };
+  // ★F: 조합 상태 머신은 macOS WKWebView 전용 우회다. Windows WebView2 등 Chromium 계열은
+  // xterm.js 네이티브 composition이 완성 음절을 onData로 정확히 1회 발화하므로, 이 우회를 함께 켜면
+  // input 핸들러가 pending에 버퍼한 글자를 리듀서가 보내고 onData의 send(data)가 다시 보내
+  // 이중 전송된다("너"->"너너" 전 글자 중복 — Windows 실측).
+  // ∴ WKWebView(AppleWebKit, 비-Chromium)에서만 input/keydown/blur/composition 리스너를 붙이고
+  // onData의 한글 defer 경로(wk 플래그)도 이 판정과 동일 기준으로만 켠다(Windows 회귀 0).
+  const _ua = navigator.userAgent;
+  const isWKWebView = /AppleWebKit/.test(_ua) && !/Chrome|Chromium|Edg\//.test(_ua);
   let imeState = initialImeState();
+  // ★한글 onData 유예 타이머 (3차 재발 수리 — 리듀서의 armDefer 액션이 (재)장전 지시):
+  // 리듀서는 순수 함수라 시간을 모른다 — 타이머만 여기서 돌리고, 만료 시 deferTimeout 이벤트로
+  // 되먹인다. 취소는 리듀서 상태(deferred="")가 담당하므로 타이머 자체는 만료 시 no-op이어도 안전.
+  let imeDeferTimer: number | undefined;
   const applyIme = (event: ImeEvent) => {
     const { state, actions } = imeStep(imeState, event);
     imeState = state;
     for (const a of actions) {
       if ("send" in a) sendRaw(a.send);
-      else dbg(a.debug);
+      else if ("armDefer" in a) {
+        if (imeDeferTimer !== undefined) clearTimeout(imeDeferTimer);
+        imeDeferTimer = window.setTimeout(() => {
+          imeDeferTimer = undefined;
+          applyIme({ kind: "deferTimeout" });
+        }, DEFER_MS);
+      } else dbg(a.debug);
     }
   };
 
   term.onData((data) => {
     // 완성 음절은 그대로 PTY로 — 잔여 pending이 있으면 리듀서가 순서 보존 후 함께 전송(안전장치).
     // Windows 등 비-WKWebView에선 input 핸들러 미배선이라 pending이 항상 비어 순수 send(data)와 동일.
-    applyIme({ kind: "onData", data });
+    // wk=true(WKWebView)면 한글 data는 리듀서가 유예(defer)해 이중배달을 흡수한다(3차 재발 수리).
+    dbg(`onData recv "${data}" pending="${imeState.pending}" deferred="${imeState.deferred}"`);
+    applyIme({ kind: "onData", data, wk: isWKWebView });
   });
-
-  // ★F: 위 조합 상태 머신은 macOS WKWebView 전용 우회다. Windows WebView2 등 Chromium 계열은
-  // xterm.js 네이티브 composition이 완성 음절을 onData로 정확히 1회 발화하므로, 이 우회를 함께 켜면
-  // input 핸들러가 pending에 버퍼한 글자를 리듀서가 보내고 onData의 send(data)가 다시 보내
-  // 이중 전송된다("너"->"너너" 전 글자 중복 — Windows 실측).
-  // ∴ WKWebView(AppleWebKit, 비-Chromium)에서만 input/keydown/blur/composition 리스너를 붙인다(macOS 회귀 0).
-  const _ua = navigator.userAgent;
-  const isWKWebView = /AppleWebKit/.test(_ua) && !/Chrome|Chromium|Edg\//.test(_ua);
   if (isWKWebView) {
     const ta = term.textarea;
     if (ta) {


### PR DESCRIPTION
## 증상

macOS(WKWebView)에서 한글 타이핑 시 초성 선유출·음절 복제가 발생합니다:

- 입력 "한글" → 화면 `ㅎ한ㄱ글`
- 입력 "다" → `다다`

## 원인

macOS WKWebView 프로필은 한글 키마다 **xterm onData와 input 이벤트 머신 두 경로가 같은 글자를 모두 배달**합니다(이중배달). `ui/src/ime.ts` 리듀서의 onData 케이스가 `flush(pending) + send(data)` 즉시 전송이라 이 프로필에 무방비 — pending flush와 겹쳐 초성 선유출("ㅁ마")·음절 복제("다다")가 됩니다.

실측 시퀀스(리듀서 재생으로 바이트 정합 확인):

- A: `insertText'ㅁ'` → `onData'마'` → RT`'마'` ⇒ `"ㅁ"+"마"+DEL"마"` (화면 `ㅁ마`)
- B: `insertText'ㄷ'` → RT`'다'` → `onData'다'` ⇒ `"다다"`

## 수리

한글 onData를 즉시 전송하지 않고 **유예(defer) 버퍼**에 40ms 보관합니다:

- input 머신이 같은 글자를 받아가면 취소 — containment 양방향 4분기(동일 / deferred⊃data 부분취소 / data⊃deferred 병합커밋 전체취소 / 유예 홑자모가 커밋 음절의 초성이면 흡수)
- 아무도 받아가지 않으면 타임아웃 방출(유실 0) — 방출 시 pending(구분)이 먼저 나가 시간순 보존
- **macOS WKWebView 배선 한정**(`wk` 플래그): Windows WebView2 등 Chromium 계열은 종전 즉시 send 경로 그대로 — 회귀 없음(Windows는 xterm 네이티브 composition이 정확히 1회 발화)

리듀서는 순수 함수 유지 — 타이머는 배선(main.ts)이 `armDefer` 액션으로 돌리고 만료 시 `deferTimeout` 이벤트로 되먹입니다.

## 커밋 구성 (4)

1. 빈 onData가 조합중 홑자모를 유출하는 버그 차단 (실기기 계측)
2. onData 이중배달 defer를 리듀서로 이식 (근본수리)
3. 리뷰 보강 3건 — 누적 부분취소·시간순 방출·U+1100 초성
4. 리뷰 보강 — inverse-prefix(병합 커밋이 유예분 포함) 취소 + onData 계약 주석 정정

## 검증

- `cd ui && bun test` — **87/87 통과** (v0.12.21 기존 테스트 + 회귀 테스트 추가분 포함)
- 실기기(macOS aarch64) 로컬 빌드로 실타이핑 검증 — `cysImeDebug=1` 계측 로그로 defer/취소 경로 확인
- 자동 업데이트로 v0.12.21(무패치) 설치 시 즉시 재발함을 실증 — 본 수정이 업스트림에 병합돼야 macOS 사용자 재발이 끝납니다