### PR TITLE
fix(win): cys.EXE verb 오인식 + bypass 수락메뉴로 인한 노드 사망 (Windows)

### DIFF
--- a/cysjavis-pack/agents.json
+++ b/cysjavis-pack/agents.json
@@ -1,10 +1,10 @@
 {
   "_doc": "에이전트 어댑터 정의. launch-agent가 사용: 기동 명령 → inject_delay_secs 대기 → 역할 디렉티브를 stdin push. clear_cmd=cycle-agent의 컨텍스트 초기화 명령, resume_arg=restore/node-recover의 대화 기억 복원 플래그, approval_patterns=데몬 승인 격상 스캔(자동 응답 절대 없음 — 감지·feed 격상만). 사용자 환경에 맞게 수정 가능(~/.cys/pack/agents.json).",
   "claude": {
-    "cmd": "claude --dangerously-skip-permissions",
+    "cmd": "claude --permission-mode bypassPermissions",
     "env": { "CLAUDE_CONFIG_DIR": "${CYS_ACCOUNT_DIR:-$HOME/.cys/claude}" },
     "inject_delay_secs": 10,
-    "notes": "Claude Code. cys 전용 CLAUDE_CONFIG_DIR(~/.cys/claude)로 기동 — 사용자 ~/.claude(외부 터미널 체계·구 지침 오염 가능)와 격리(읽지도 지우지도 않음). RC-3(B′): cmd=순수 명령·env=맵 구조. unix launch-agent는 `KEY=\"val\" cmd` 인라인으로 재조립(셸이 ${:-}·$HOME 전개·기존과 byte-identical), Windows는 순수 cmd send + surface.create가 해소된 env를 builder.env 주입(powershell이 POSIX env-assign 미해석 회귀 차단). macOS 인증은 계정 단위 Keychain이라 격리해도 로그인 유지. ready_marker(❯) 감지 후 주입. 폴더 신뢰 프롬프트는 launch-agent가 자동 확인한다.",
+    "notes": "Claude Code. cys 전용 CLAUDE_CONFIG_DIR(~/.cys/claude)로 기동 — 사용자 ~/.claude(외부 터미널 체계·구 지침 오염 가능)와 격리(읽지도 지우지도 않음). RC-3(B′): cmd=순수 명령·env=맵 구조. unix launch-agent는 `KEY=\"val\" cmd` 인라인으로 재조립(셸이 ${:-}·$HOME 전개·기존과 byte-identical), Windows는 순수 cmd send + surface.create가 해소된 env를 builder.env 주입(powershell이 POSIX env-assign 미해석 회귀 차단). macOS 인증은 계정 단위 Keychain이라 격리해도 로그인 유지. ready_marker(❯) 감지 후 주입. 폴더 신뢰 프롬프트는 launch-agent가 자동 확인한다. ★Windows 회귀 수정: cmd를 `--dangerously-skip-permissions`→`--permission-mode bypassPermissions`로 교체. 전자는 최초 실행 시 'Bypass Permissions mode' 수락 메뉴(❯ 1.No,exit / 2.Yes)를 띄우는데, 런처의 ready_marker(❯)가 이 메뉴 행을 준비완료로 오탐→지침 조기주입+기본 No,exit 자동선택으로 노드가 죽었다. 후자는 동일 bypass 상태를 대화형 게이트 없이 설정해 메뉴 자체를 제거(fresh config·미인증 상태에서도 메뉴 미출현 실측 검증). 진짜 근본수리(런처 ready-marker를 실제 입력창 시그니처로 교체)는 handlers.rs 별도 과제.",
     "ready_marker": "❯",
     "clear_cmd": "/clear",
     "resume_arg": "--resume {session_id}",

--- a/cysjavis-pack/bin/javis_idempotency.py
+++ b/cysjavis-pack/bin/javis_idempotency.py
@@ -76,7 +76,9 @@ def _extract_verb(argv):
     if not argv:
         return None
     first = os.path.basename(str(argv[0]))
-    if first != "cys":
+    # Windows 는 shutil.which 가 'cys.EXE'(대문자·.cmd/.bat) 로 해소 — 확장자·케이스 허용해
+    # basename!='cys' 오탐 차단(cys.py 등 비바이너리는 여전히 미인식). unix('cys')는 그대로.
+    if first.lower() not in ("cys", "cys.exe", "cys.cmd", "cys.bat"):
         return None
     i = 1
     while i < len(argv):


### PR DESCRIPTION
## 문제 (Windows 전용 회귀 2건 · 둘 다 pack 파일 · Rust 빌드 불필요)

### 1. `_extract_verb` 가 대문자 확장자 실행파일을 인식 못 함 → preflight C53 RED
`shutil.which("cys")` 는 Windows에서 대문자 확장자(cys.EXE)를 반환하는데, `_extract_verb` 가 basename 을 정확히 `"cys"` 와만 비교해 verb=None 을 반환했다. 그 결과 `cmd_check` 의 유일한 cys 호출(`cys status --json`)이 무시돼 `javis_idempotency --self-test` 가 AssertionError 로 실패(C53 FAIL).

### 2. bypass 수락 메뉴에서 노드 전멸
`agents.json` 의 `claude.cmd = claude --dangerously-skip-permissions` 는 최초 실행 시 'Bypass Permissions mode' 수락 메뉴(1. No, exit / 2. Yes, I accept)를 띄운다. launch-agent 의 ready_marker(❯) 가 이 메뉴 행을 준비완료로 오탐 → 지침을 조기 주입하고 기본값 'No, exit' 가 선택돼 claude 가 즉시 종료 → cso·worker·reviewer 노드가 모두 죽었다.

## 수정
1. `_extract_verb`: `first.lower()` 를 {cys, cys.exe, cys.cmd, cys.bat} 로 비교(비바이너리 cys.py 등은 여전히 미인식).
2. `agents.json`: `claude.cmd` 를 `--permission-mode bypassPermissions` 로 교체 — 동일 bypass 상태를 대화형 게이트 없이 설정해 수락 메뉴 자체를 제거.

## 검증
- `javis_idempotency.py --self-test` → PASS (C53 PASS 회복).
- fresh config·미인증에서 `--permission-mode bypassPermissions` 실행 시 수락 메뉴 미출현 실측.
- launch-agent 엔드투엔드로 노드 정상 각성(지침 주입까지) 확인.

## 남긴 것
진짜 근본수리(launcher ready_marker 를 ❯ 단독이 아닌 실제 입력창 시그니처로 교체)는 src/bin/cysd/ 별도 과제 — 본 PR 2)로 실질 해소되므로 Rust 변경 없이 배포 가능.