### PR TITLE
fix(pack): C53 self-test Windows portability - strip executable extension in _extract_verb

### DIFF
--- a/cysjavis-pack/bin/javis_idempotency.py
+++ b/cysjavis-pack/bin/javis_idempotency.py
@@ -76,6 +76,11 @@ def _extract_verb(argv):
     if not argv:
         return None
     first = os.path.basename(str(argv[0]))
+    # Windows: shutil.which("cys")가 'cys.EXE' 풀패스를 반환 — 실행 확장자를 벗겨 비교한다.
+    # 미탈피 시 verb=None → self-test spy가 cys 호출을 전부 놓쳐 C53이 Windows에서만 FAIL.
+    root, ext = os.path.splitext(first)
+    if ext.lower() in (".exe", ".cmd", ".bat", ".com"):
+        first = root
     if first != "cys":
         return None
     i = 1


### PR DESCRIPTION
## 요약
`javis_idempotency.py --self-test`(preflight C53)가 **Windows에서만 FAIL**하는 이식성 결함의 5줄 수정입니다.

## 결함 (실측)
- `_extract_verb`(:78-80)가 `os.path.basename(argv[0])`을 `"cys"`와 정확 비교하는데, Windows에서 `shutil.which("cys")`는 `C:\...\cys.EXE`를 반환 → basename `"cys.EXE" != "cys"` → verb=None.
- 결과: self-test spy(`_spy_cmd_check`, :166-167)가 cys 호출을 전부 놓쳐 `assert cys_calls` 실패. Unix는 확장자가 없어 통과 — Windows 전용 FAIL.
```
AssertionError: cmd_check 가 cys status 조차 호출하지 않음(spy 미작동 의심)
```

## 수정
basename에서 실행 확장자(`.exe/.cmd/.bat/.com`, 대소문자 무시)를 탈피한 뒤 비교. 관찰/변이 분류 로직은 무변경.

## 검증
- Windows 11 + 동봉 런타임 python 3.12.10: 수정 후 `--self-test` → **OK** (표면 커버리지 포함 전 배터리), preflight **C53 PASS**, 부트 READY.
- 3개 운영 부서에서 독립 재현·수정 검증(원시 로그 보유, 요청 시 제공).

## 참고
동반 리포트 이슈(운영팀 기술 리포트, Windows 실측 8건)의 A-1 항목입니다. 판정·수정요구는 이 PR 코멘트로 주시면 저희 AI 총괄이 즉시 후속합니다.
