### PR TITLE
fix(pack): add safe_path guard to 6 entry points with bare sibling imports

### DIFF
--- a/cysjavis-pack/bin/javis_event.py
+++ b/cysjavis-pack/bin/javis_event.py
@@ -10,9 +10,11 @@ exit codes: 0 ok · 2 usage · 6 invalid(타입/스키마 위반)
 """
 import argparse
 import json
+import os
 import re
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # safe_path(-P) guard for sibling imports (same idiom as javis_replay.py)
 import javis_scrub  # ★G2: 기록·전파 직전 비밀 마스킹(같은 폴더 형제 모듈 — 부재 시 즉시 실패=fail-closed)
 
 EXIT_OK, EXIT_USAGE, EXIT_INVALID = 0, 2, 6

--- a/cysjavis-pack/bin/javis_memory.py
+++ b/cysjavis-pack/bin/javis_memory.py
@@ -30,6 +30,8 @@ import sys
 import tempfile
 import time
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # safe_path(-P) guard for sibling imports (same idiom as javis_replay.py)
+
 # P0.2 메모리 포이즌 WARN 게이트(구현설계서 v2 §3) — javis_skillscan(같은 bin) 있으면 활성.
 #   WARN 전용: 메모리 쓰기를 절대 차단하지 않는다(생명선·자기충돌·자율주행 증류 굶주림 방지 — 성찰 B-2).
 # ★G14(cokacdir 성찰 2026-07-04): 스캐너 부재의 '조용한 fail-open' 제거 — 쓰기는 규약대로

--- a/cysjavis-pack/bin/javis_memory_inject.py
+++ b/cysjavis-pack/bin/javis_memory_inject.py
@@ -14,6 +14,8 @@ import sys
 import threading
 import uuid
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # safe_path(-P) guard for sibling imports (same idiom as javis_replay.py)
+
 MAX_MEMOS = 2
 MAX_BODY = 4096
 MAX_PER_SESSION = 5

--- a/cysjavis-pack/bin/javis_orchestra.py
+++ b/cysjavis-pack/bin/javis_orchestra.py
@@ -60,6 +60,8 @@ import shutil
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # safe_path(-P) guard for sibling imports (same idiom as javis_replay.py)
+
 # 4차 앵커4-1: 프로젝트 상주 의무 노드(grok은 선택). 이것은 *표준(Tier-2 이상) 기본 로스터*다.
 # ★check 가 실제로 검증하는 것은 effective_required_roles()(=감지 폴백 적용) — REQUIRED_ROLES 는
 # 계약·문서용 표준 상수로 보존한다. agy/codex 미감지 시 리뷰어 슬롯은 Claude 대체로 치환된다.

--- a/cysjavis-pack/bin/javis_task.py
+++ b/cysjavis-pack/bin/javis_task.py
@@ -27,6 +27,8 @@ import sys
 import time
 import uuid
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # safe_path(-P) guard for sibling imports (same idiom as javis_replay.py)
+
 ROOT = os.environ.get("JAVIS_ROOT") or os.getcwd()  # 개인경로 하드코딩 금지(pack scan gate) — env 또는 CWD(워크스페이스 루트에서 호출)
 TASKS_DIR = os.path.join(ROOT, "_round", "tasks")
 

--- a/cysjavis-pack/bin/javis_wakeup.py
+++ b/cysjavis-pack/bin/javis_wakeup.py
@@ -30,6 +30,7 @@ import sys
 import time
 import uuid
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))  # safe_path(-P) guard for sibling imports (same idiom as javis_replay.py)
 import javis_scrub  # ★G2: 원장 기록 직전 비밀 마스킹(같은 폴더 형제 모듈 — 부재 시 즉시 실패=fail-closed)
 
 ROOT = os.environ.get("JAVIS_ROOT") or os.getcwd()  # 개인경로 하드코딩 금지(pack scan gate) — env 또는 CWD(워크스페이스 루트에서 호출)


### PR DESCRIPTION
## 요약
동봉 런타임이 `-P`(safe_path)로 python을 기동하므로 스크립트 자기 디렉터리가 `sys.path`에서 제외됩니다. 가드 없는 bare 형제 import를 쓰는 엔트리포인트 6종에 기존 관례(`javis_replay.py:17`)와 **동형의 가드 1줄**을 추가합니다 (총 11줄: 가드 6 + `javis_event.py`의 `import os` 1 + 주석).

## 결함 (실측 — 중립 cwd에서 재현)
| 파일:줄 | import | 증상 |
|---|---|---|
| javis_event.py:16 | javis_scrub (모듈레벨) | **로드 즉시 크래시** |
| javis_wakeup.py:33 | javis_scrub (모듈레벨) | **로드 즉시 크래시** (웨이크업 배달 사망) |
| javis_memory.py:39 · javis_memory_inject.py:127 | javis_skillscan (try) | 포이즌 스캐너 조용히 OFF(**fail-open**) |
| javis_orchestra.py:194 · :753 | javis_boot_node·javis_verdict (try) | 생존추정 빈 dict·verdict 검증 무력화 |
| javis_task.py:392 | javis_boot_node (try) | 워커 idle 관측 상실 |

```
$ cd <중립> && python3 -P bin/javis_wakeup.py --help
ModuleNotFoundError: No module named 'javis_scrub'
```

## 수정
각 파일 stdlib import 블록 직후에:
```python
sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
```
이미 절반의 bin 스크립트가 쓰는 패턴과 byte-동형이라 스타일 이탈이 없습니다.

## 검증
- 중립 cwd + `-P`: HARD 2종 `--help` 정상 출력, DEGRADE 4종 형제 import 로드 OK.
- 포이즌 스캐너 부활(`javis_memory.py verify` 경고 소멸) 실측.
- 3개 운영 부서 독립 교차검증.

## 참고
동반 리포트 이슈의 A-2 항목입니다. 형제-import 전수 감사표(11파일)도 이슈에 있습니다.
