### PR TITLE
fix(pack): treat agents.json as user-owned (same rationale as schedule.json)

### DIFF
--- a/src/pack.rs
+++ b/src/pack.rs
@@ -340,6 +340,11 @@ pub(crate) fn is_user_owned(rel: &str) -> bool {
         // 사용자 잡이 소실(비가역 데이터 손실)된다. user 소유로 보존하고, built-in 잡(phoenix-*)은 데몬 부트 시
         // 코드가 idempotent ensure 한다(cysd schedule::ensure_builtin_jobs). 기본 잡 드리프트(복구 가능) < 사용자 잡 소실.
         || rel == "schedule.json"
+        // agents.json 도 schedule.json 과 같은 혼합 파일이다: 사용자가 머신별 에이전트 실경로(cmd)와
+        // 격리 환경(env)을 편집한다(특히 Windows — 템플릿의 ~/.local/bin 류 POSIX 경로는 미해석이라
+        // 사용자 수정이 필수). 강제갱신이 덮으면 노드 기동이 즉사하고, 매 heal 마다 재적용이 강요된다.
+        // 템플릿 전진분은 user-owned 규약대로 `<rel>.new` 병치로 가시화된다(pack-merge 검토 경로 동일).
+        || rel == "agents.json"
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 요약
`agents.json`을 `is_user_owned`(src/pack.rs) 화이트리스트에 추가합니다 — **schedule.json을 추가하신 사유(B2-1/W3)가 글자 그대로 성립하는 파일**입니다.

## 결함 (실측)
- agents.json은 사용자가 머신별로 반드시 편집하는 혼합 파일입니다: 에이전트 실행 경로(cmd)와 격리 환경(env). 특히 Windows에선 템플릿의 POSIX 경로(`~/.local/bin/agy`, `~/.npm-global/bin/codex`)가 해석되지 않아 **수정 없이는 gemini/codex 노드 기동 자체가 불가**합니다.
- 현재 system 소유라 매 heal(데몬 부팅 `pack::install(false)` = cysd/main.rs:107, 온보딩 init-pack)마다 템플릿으로 강제 원복 → 노드 기동 즉사 → 사용자 재적용 강제. 저희 실측: 3개 부서에서 **하루 5회+ 원복**.

## 수정
schedule.json arm 바로 아래 1줄 (+근거 주석):
```rust
|| rel == "agents.json"
```
- 템플릿 전진분은 기존 user-owned 규약(`<rel>.new` 병치 + `.merge-pending.json` + `cys pack-merge`)으로 가시화되므로, 벤더 변경이 사용자에게 숨지 않습니다 — schedule.json과 완전 동일한 수명주기.

## 검증
- 판정 로직은 `decide_file_action`의 기존 user-owned 경로를 그대로 타므로 신규 분기 없음.
- ⚠정직 고지: 저희 운영 머신에 Rust 툴체인이 없어 `cargo test` 미실행 — 바로 아랫줄 schedule.json arm과 동형이라 기존 user-owned 테스트가 커버한다고 판단했습니다. CI에서 확인 부탁드립니다.

## 이 1줄의 효과
저희 3개 부서가 매 재기동마다 겪는 "agents.json 원복 → 커스텀 재적용" 소모전이 근본 소멸합니다. 동반 리포트 이슈의 A-3 항목입니다.
