### PR TITLE
fix(idempotency): recognize cys.EXE/cys.exe in _extract_verb (Windows)

### DIFF
--- a/cysjavis-pack/bin/javis_idempotency.py
+++ b/cysjavis-pack/bin/javis_idempotency.py
@@ -76,7 +76,8 @@ def _extract_verb(argv):
     if not argv:
         return None
     first = os.path.basename(str(argv[0]))
-    if first != "cys":
+    first_noext = os.path.splitext(first)[0]   # Windows: cys.EXE/cys.exe 도 인식
+    if first_noext.lower() != "cys":
         return None
     i = 1
     while i < len(argv):


### PR DESCRIPTION
Windows 배포 바이너리가 cys.EXE(대문자 확장자)로 실행되는 경우, 기존 idempotency 검증기(_extract_verb)가 이를 인식하지 못해 preflight C53.idempotency 체크가 실패하던 문제를 수정합니다.

- _extract_verb에 cys.EXE / cys.exe 대소문자 변형을 모두 인식하도록 2줄 수정
- 로컬에서 preflight self-test로 재검증 완료