### PR TITLE
fix(ci): make release shellcheck portable

### DIFF
--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -14,9 +14,15 @@ BROWSER_RUNTIME_SOURCES = ROOT / "release" / "browser-runtime-sources.json"
 WINDOWS_BUILD = ROOT / "scripts" / "build-windows-unsigned.ps1"
 BROWSER_MAC_SIGN = ROOT / "scripts" / "runtime-stage-sign-macos.sh"
 BROWSER_WINDOWS_SIGN = ROOT / "scripts" / "runtime-stage-sign-windows.ps1"
+REMOTE_VERIFIER = ROOT / "scripts" / "verify-release-remote.sh"
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
+    def test_remote_verifier_avoids_shellcheck_ambiguous_boolean_chains(self) -> None:
+        verifier = REMOTE_VERIFIER.read_text(encoding="utf-8")
+
+        self.assertNotRegex(verifier, re.compile(r"\]\s*&&\s*\[.*\]\s*\|\|\s*usage"))
+
     def test_candidate_workflow_has_one_draft_assembler_and_no_public_publish(self) -> None:
         candidate = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         publish = PUBLISH_WORKFLOW.read_text(encoding="utf-8")

--- a/scripts/verify-release-remote.sh
+++ b/scripts/verify-release-remote.sh
@@ -22,7 +22,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-[ -n "$VERSION" ] && [ -n "$RELEASE_DIR" ] && [ -n "$SITE_ROOT" ] || usage
+if [ -z "$VERSION" ] || [ -z "$RELEASE_DIR" ] || [ -z "$SITE_ROOT" ]; then
+  usage
+fi
 case "$SITE_ROOT" in
   https://*) ;;
   http://127.0.0.1:*|http://localhost:*) ;;


### PR DESCRIPTION
## What changed

- replaced the remote verifier's ambiguous `A && B || usage` argument guard with an explicit `if`
- added a static regression test so this ShellCheck portability failure cannot recur

## Root cause

The v0.13.2 tag's release-contracts job passed all 53 Python tests, then Ubuntu ShellCheck treated SC2015 as a failing diagnostic. The local ShellCheck build did not fail on the same informational diagnostic, so the environment-specific difference was not visible before the tag run.

## Impact

No release asset or draft was created by the failed tag run. This change affects only the verifier's required-argument guard; its behavior remains fail-closed.

## Validation

- release scripts: 54/54
- focused remote verifier: 5/5
- shellcheck, actionlint, diff check, and secret scan
