### PR TITLE
Fix cross-platform release runner regressions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,6 +311,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if brew tap | grep -Fxq 'aws/tap'; then
+            brew untap aws/tap
+          fi
           brew install minisign
           minisign --version
 

--- a/cysjavis-pack/browserd/tests/unit.test.ts
+++ b/cysjavis-pack/browserd/tests/unit.test.ts
@@ -1,5 +1,6 @@
 // unit.test.ts — 순수 로직 단위 테스트 (bun test). 브라우저 미기동.
 import { test, expect } from "bun:test";
+import { join } from "node:path";
 import {
   genToken,
   capText,
@@ -57,8 +58,12 @@ test("UNTRUSTED_HEADER: 지시 무시 문구 포함", () => {
 
 test("strict packaged engine stores endpoint only under supervisor-owned root", () => {
   expect(resolveBrowserRoot("/home/user", "/private/engine", "1")).toBe("/private/engine");
-  expect(resolveBrowserRoot("/home/user", "/private/engine", "0")).toBe("/home/user/.cys/browser");
-  expect(resolveBrowserRoot("/home/user", undefined, "1")).toBe("/home/user/.cys/browser");
+  expect(resolveBrowserRoot("/home/user", "/private/engine", "0")).toBe(
+    join("/home/user", ".cys", "browser"),
+  );
+  expect(resolveBrowserRoot("/home/user", undefined, "1")).toBe(
+    join("/home/user", ".cys", "browser"),
+  );
 });
 
 test("strict packaged engine binds status and endpoint to signed runtime identity", () => {

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -127,6 +127,16 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertRegex(candidate, re.compile(r"brew install minisign[\s\S]+minisign --version"))
         self.assertRegex(candidate, re.compile(r"choco install minisign[\s\S]+minisign --version"))
 
+    def test_macos_minisign_install_removes_only_the_known_untrusted_aws_tap(self) -> None:
+        candidate = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        safe_install = """if brew tap | grep -Fxq 'aws/tap'; then
+            brew untap aws/tap
+          fi
+          brew install minisign"""
+
+        self.assertIn(safe_install, candidate)
+        self.assertNotIn("HOMEBREW_NO_VERIFY_ATTESTATIONS", candidate)
+
     def test_browser_runtime_is_built_and_staged_from_pinned_sources_before_signing(self) -> None:
         candidate = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         sources = json.loads(BROWSER_RUNTIME_SOURCES.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- remove only the known untrusted `aws/tap` before installing minisign on macOS runners
- keep Homebrew trust and attestation checks enabled
- make the browser runtime path assertion use the host OS path separator on Windows
- pin both runner regressions with release-contract tests

## Verification

- `python3 -m unittest discover -s scripts/tests -v` (55 passed)
- `bun run test` in `cysjavis-pack/browserd` (47 unit + 47 integration passed)
- `actionlint .github/workflows/*.yml`
- release shell scripts pass `shellcheck`
- `sh scripts/version-check.sh`
- `bash scripts/secret-scan.sh --all`
