### PR TITLE
Fix portable minisign installation probe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,7 @@ jobs:
             brew untap aws/tap
           fi
           brew install minisign
-          minisign --version
+          test -x "$(command -v minisign)"
 
       - name: Install Browser Runtime minisign verifier (Windows)
         if: matrix.platform == 'windows-latest'
@@ -323,8 +323,7 @@ jobs:
         run: |
           choco install minisign --yes --no-progress
           if ($LASTEXITCODE -ne 0) { throw 'minisign installation failed' }
-          minisign --version
-          if ($LASTEXITCODE -ne 0) { throw 'minisign verification failed' }
+          Get-Command minisign -ErrorAction Stop | Out-Null
 
       - name: Materialize Browser Runtime release trust inputs (macOS)
         if: matrix.platform == 'macos-latest'

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -124,8 +124,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
             self.assertGreaterEqual(candidate.count(name), 2, f"missing cross-platform wiring: {name}")
         self.assertIn("CYS_BROWSER_RUNTIME_SECRET_KEY_B64", candidate)
         self.assertIn("CYS_BROWSER_RUNTIME_PUBLIC_KEY_B64", candidate)
-        self.assertRegex(candidate, re.compile(r"brew install minisign[\s\S]+minisign --version"))
-        self.assertRegex(candidate, re.compile(r"choco install minisign[\s\S]+minisign --version"))
+        self.assertRegex(candidate, re.compile(r"brew install minisign[\s\S]+command -v minisign"))
+        self.assertRegex(candidate, re.compile(r"choco install minisign[\s\S]+Get-Command minisign"))
+        self.assertNotIn("minisign --version", candidate)
 
     def test_macos_minisign_install_removes_only_the_known_untrusted_aws_tap(self) -> None:
         candidate = RELEASE_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- replace the unsupported cross-platform `minisign --version` probe
- verify the installed executable with `command -v` on macOS and `Get-Command` on Windows
- add a regression assertion that forbids the unsupported option

## Root cause

The macOS runner successfully removed the untrusted tap and installed minisign 0.12, then failed because that CLI does not implement `--version`. The same probe would also fail on Windows.

## Verification

- release contract suite: 55 passed
- `actionlint .github/workflows/*.yml`
- all PowerShell release scripts parse cleanly
- secret scan: 744 tracked files clean
