### PR TITLE
Fix Windows runtime compiler atomic replace

### DIFF
--- a/scripts/runtime-stage-toolchain.py
+++ b/scripts/runtime-stage-toolchain.py
@@ -54,20 +54,23 @@ def extract(args: argparse.Namespace) -> None:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         if args.output.exists():
             runtime_stage.fail("Bun compiler output already exists")
-        with tempfile.NamedTemporaryFile(
-            prefix=f".{args.output.name}.", dir=args.output.parent, delete=False
-        ) as temporary:
-            temporary_path = Path(temporary.name)
-            try:
+        temporary_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix=f".{args.output.name}.", dir=args.output.parent, delete=False
+            ) as temporary:
+                temporary_path = Path(temporary.name)
                 with archive.open(member) as payload:
                     while chunk := payload.read(1024 * 1024):
                         temporary.write(chunk)
                 temporary.flush()
-                temporary_path.chmod(0o755)
-                expected_arch = runtime_stage.TARGETS[args.target][0]
-                runtime_stage.assert_target(temporary_path, expected_arch, "Bun compiler")
-                temporary_path.replace(args.output)
-            finally:
+
+            temporary_path.chmod(0o755)
+            expected_arch = runtime_stage.TARGETS[args.target][0]
+            runtime_stage.assert_target(temporary_path, expected_arch, "Bun compiler")
+            temporary_path.replace(args.output)
+        finally:
+            if temporary_path is not None:
                 temporary_path.unlink(missing_ok=True)
 
 

--- a/scripts/tests/test_runtime_stage_toolchain.py
+++ b/scripts/tests/test_runtime_stage_toolchain.py
@@ -1,15 +1,22 @@
+import argparse
 import hashlib
+import importlib.util
 import json
 from pathlib import Path
 import struct
 import subprocess
 import tempfile
 import unittest
+from unittest import mock
 import zipfile
 
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "runtime-stage-toolchain.py"
+SPEC = importlib.util.spec_from_file_location("runtime_stage_toolchain", SCRIPT)
+module = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(module)
 
 
 class RuntimeStageToolchainTests(unittest.TestCase):
@@ -53,6 +60,42 @@ class RuntimeStageToolchainTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(output.read_bytes(), payload)
             self.assertTrue(output.stat().st_mode & 0o111)
+
+    def test_closes_temporary_compiler_before_validation_and_atomic_replace(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive, source, _ = self.fixture(directory)
+            output = root / "compiler"
+            handles = []
+            real_named_temporary_file = tempfile.NamedTemporaryFile
+
+            def recording_named_temporary_file(*args, **kwargs):
+                handle = real_named_temporary_file(*args, **kwargs)
+                handles.append(handle)
+                return handle
+
+            def assert_closed(*_args):
+                self.assertTrue(handles)
+                self.assertTrue(handles[0].closed)
+
+            args = argparse.Namespace(
+                source_manifest=source,
+                target="aarch64-apple-darwin",
+                archive=archive,
+                output=output,
+            )
+            with (
+                mock.patch.object(
+                    module.tempfile,
+                    "NamedTemporaryFile",
+                    side_effect=recording_named_temporary_file,
+                ),
+                mock.patch.object(module.runtime_stage, "assert_target", side_effect=assert_closed),
+            ):
+                module.extract(args)
+
+            self.assertEqual(len(handles), 1)
+            self.assertTrue(output.is_file())
 
     def test_rejects_same_size_compiler_archive_digest_drift(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- close the extracted Bun compiler temporary file before validation and atomic replacement
- preserve fail-closed cleanup of an incomplete temporary file
- add a regression test that asserts the file handle is closed before validation/replacement

## Root cause

The Windows release runner rejected `Path.replace()` with `WinError 32` because `NamedTemporaryFile` was still open. POSIX runners allow that rename, so the original tests could not expose the portability defect.

## Verification

- focused toolchain suite: 4 passed
- full release contract suite: 56 passed
- secret scan: 744 tracked files clean
