### PR TITLE
Pin current minisign for Windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,8 +312,24 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: pwsh
         run: |
-          choco install minisign --yes --no-progress
-          if ($LASTEXITCODE -ne 0) { throw 'minisign installation failed' }
+          $archive = Join-Path $env:RUNNER_TEMP 'minisign-0.12-win64.zip'
+          $installRoot = Join-Path $env:RUNNER_TEMP 'minisign-0.12'
+          $expectedSha256 = '37b600344e20c19314b2e82813db2bfdcc408b77b876f7727889dbd46d539479'
+          Invoke-WebRequest `
+            -Uri 'https://github.com/jedisct1/minisign/releases/download/0.12/minisign-0.12-win64.zip' `
+            -OutFile $archive
+          $actualSha256 = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualSha256 -ne $expectedSha256) {
+            throw "minisign archive SHA256 mismatch: $actualSha256"
+          }
+          Expand-Archive -LiteralPath $archive -DestinationPath $installRoot
+          $minisignDirectory = Join-Path $installRoot 'minisign-win64\x86_64'
+          $minisignExecutable = Join-Path $minisignDirectory 'minisign.exe'
+          if (-not (Test-Path -LiteralPath $minisignExecutable -PathType Leaf)) {
+            throw 'minisign executable is missing from the pinned archive'
+          }
+          $env:PATH = "$minisignDirectory;$env:PATH"
+          $minisignDirectory | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           Get-Command minisign -ErrorAction Stop | Out-Null
 
       - name: Materialize Browser Runtime release trust inputs (macOS)

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -125,7 +125,10 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("CYS_BROWSER_RUNTIME_SECRET_KEY_B64", candidate)
         self.assertIn("CYS_BROWSER_RUNTIME_PUBLIC_KEY_B64", candidate)
         self.assertRegex(candidate, re.compile(r"brew install minisign[\s\S]+command -v minisign"))
-        self.assertRegex(candidate, re.compile(r"choco install minisign[\s\S]+Get-Command minisign"))
+        self.assertRegex(candidate, re.compile(r"minisign-0\.12-win64\.zip[\s\S]+Get-Command minisign"))
+        self.assertIn("37b600344e20c19314b2e82813db2bfdcc408b77b876f7727889dbd46d539479", candidate)
+        self.assertIn("Get-FileHash", candidate)
+        self.assertNotIn("choco install minisign", candidate)
         self.assertNotIn("minisign --version", candidate)
 
     def test_macos_minisign_install_removes_only_the_known_untrusted_aws_tap(self) -> None:


### PR DESCRIPTION
## Summary

- replace Chocolatey's stale minisign 0.8 package with the official 0.12 Windows archive
- pin and verify the archive with SHA256 before extraction
- expose only the x86_64 executable through the runner PATH
- forbid the Chocolatey install path in the release regression contract

## Root cause

Chocolatey installed minisign 0.8, which rejects the noninteractive `-W` option and the current release key format. macOS already used minisign 0.12 successfully.

## Verification

- official release asset downloaded and independently hashed
- release contract suite: 57 passed
- `actionlint .github/workflows/*.yml`
- all PowerShell release scripts parse cleanly
- secret scan: 744 tracked files clean
