### PR TITLE
fix(release): hash the installed Windows GUI bytes

### DIFF
--- a/scripts/build-windows-unsigned.ps1
+++ b/scripts/build-windows-unsigned.ps1
@@ -40,25 +40,13 @@ python scripts/browser-runtime-metadata.py prepare `
 if ($LASTEXITCODE -ne 0) { throw 'Browser Runtime metadata signing/verification failed' }
 $env:CYS_BROWSER_V2_RELEASE_QUALIFIED = '1'
 
-# First build the exact unsigned GUI executable. The final cysd sidecar embeds
-# this digest and accepts Browser authority registrations only from this byte-
-# identical canonical sibling, replacing CA-backed publisher identity without
-# weakening the process/path/incarnation checks.
+# A plain `cargo build` omits Tauri's release features, while a full Tauri build
+# temporarily patches the GUI only inside the NSIS copy and restores the
+# unpatched executable afterwards. Compile once with Tauri's exact release
+# settings but without bundling, then apply the same official UNK -> NSS marker
+# substitution before hashing. `tauri bundle` consumes that already-built PE;
+# the final comparison remains fail-closed if any later step changes it.
 Remove-Item Env:\CYS_WINDOWS_GUI_SHA256 -ErrorAction SilentlyContinue
-bash scripts/bundle-prep.sh
-if ($LASTEXITCODE -ne 0) { throw 'preliminary bundle-prep failed' }
-cargo build --locked --release --target $target -p cys-app
-if ($LASTEXITCODE -ne 0) { throw 'preliminary unsigned Windows GUI build failed' }
-$gui = (Resolve-Path "target\$target\release\cys-app.exe").Path
-$guiHash = (Get-FileHash -LiteralPath $gui -Algorithm SHA256).Hash.ToLowerInvariant()
-if ($guiHash -notmatch '^[0-9a-f]{64}$') { throw 'Unsigned Windows GUI SHA-256 is invalid' }
-$env:CYS_WINDOWS_GUI_SHA256 = $guiHash
-
-# Rebuild cysd with the release GUI digest, then let Tauri run the same
-# bundle-prep once more under the identical environment before NSIS packaging.
-bash scripts/bundle-prep.sh
-if ($LASTEXITCODE -ne 0) { throw 'hash-pinned bundle-prep failed' }
-
 $configPath = Join-Path $env:RUNNER_TEMP 'tauri-release-windows-unsigned.json'
 $config = @{
   bundle = @{
@@ -67,8 +55,26 @@ $config = @{
   }
 }
 $config | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $configPath -Encoding UTF8
-bunx '@tauri-apps/cli@2' build --target $target --config $configPath
-if ($LASTEXITCODE -ne 0) { throw 'Tauri unsigned Windows release build failed' }
+bunx '@tauri-apps/cli@2' build --no-bundle --target $target --config $configPath
+if ($LASTEXITCODE -ne 0) { throw 'Tauri exact Windows GUI compile failed' }
+
+$gui = (Resolve-Path "target\$target\release\cys-app.exe").Path
+python scripts/patch-tauri-bundle-type.py --executable $gui --bundle-type nsis
+if ($LASTEXITCODE -ne 0) { throw 'Tauri NSIS bundle marker patch failed' }
+$guiHash = (Get-FileHash -LiteralPath $gui -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($guiHash -notmatch '^[0-9a-f]{64}$') { throw 'Unsigned Windows GUI SHA-256 is invalid' }
+$env:CYS_WINDOWS_GUI_SHA256 = $guiHash
+
+# Rebuild and restage cysd with the exact installed-GUI digest. Bundle the
+# already-built, already-patched PE without invoking a second Cargo app build.
+bash scripts/bundle-prep.sh
+if ($LASTEXITCODE -ne 0) { throw 'hash-pinned bundle-prep failed' }
+$nsisDir = "target\$target\release\bundle\nsis"
+if (Test-Path -LiteralPath $nsisDir) {
+  Remove-Item -LiteralPath $nsisDir -Recurse -Force
+}
+bunx '@tauri-apps/cli@2' bundle --bundles nsis --target $target --config $configPath
+if ($LASTEXITCODE -ne 0) { throw 'Tauri unsigned Windows release bundle failed' }
 
 $finalGuiHash = (Get-FileHash -LiteralPath $gui -Algorithm SHA256).Hash.ToLowerInvariant()
 if ($finalGuiHash -ne $guiHash) {

--- a/scripts/patch-tauri-bundle-type.py
+++ b/scripts/patch-tauri-bundle-type.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Apply Tauri's exact in-place bundle-type marker before release hashing."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+UNKNOWN = b"__TAURI_BUNDLE_TYPE_VAR_UNK"
+BUNDLE_TYPES = {"nsis": b"__TAURI_BUNDLE_TYPE_VAR_NSS"}
+
+
+class PatchError(ValueError):
+    pass
+
+
+def patch_bundle_type(executable: Path, bundle_type: str) -> None:
+    if executable.is_symlink() or not executable.is_file():
+        raise PatchError(f"executable is not a regular file: {executable}")
+    replacement = BUNDLE_TYPES[bundle_type]
+    if len(replacement) != len(UNKNOWN):
+        raise PatchError("Tauri bundle marker length mismatch")
+
+    original = executable.read_bytes()
+    occurrences = original.count(UNKNOWN)
+    if occurrences != 1:
+        raise PatchError(
+            f"expected exactly one Tauri bundle marker, found {occurrences}"
+        )
+    patched = original.replace(UNKNOWN, replacement, 1)
+
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=f".{executable.name}.",
+            suffix=".partial",
+            dir=executable.parent,
+            delete=False,
+        ) as temporary:
+            temporary_name = temporary.name
+            temporary.write(patched)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.chmod(temporary_name, executable.stat().st_mode)
+        os.replace(temporary_name, executable)
+        temporary_name = None
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--executable", required=True, type=Path)
+    parser.add_argument("--bundle-type", required=True, choices=sorted(BUNDLE_TYPES))
+    args = parser.parse_args()
+    try:
+        patch_bundle_type(args.executable, args.bundle_type)
+    except (OSError, PatchError) as error:
+        print(f"Tauri bundle marker patch failed: {error}", file=sys.stderr)
+        return 1
+    print(f"Tauri bundle marker fixed before hashing: {args.bundle_type}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_patch_tauri_bundle_type.py
+++ b/scripts/tests/test_patch_tauri_bundle_type.py
@@ -1,0 +1,57 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PATCHER = ROOT / "scripts" / "patch-tauri-bundle-type.py"
+UNKNOWN = b"__TAURI_BUNDLE_TYPE_VAR_UNK"
+NSIS = b"__TAURI_BUNDLE_TYPE_VAR_NSS"
+
+
+class PatchTauriBundleTypeTests(unittest.TestCase):
+    def run_patcher(self, payload: bytes) -> tuple[subprocess.CompletedProcess[str], Path, bytes]:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        executable = Path(temporary.name) / "cys-app.exe"
+        executable.write_bytes(payload)
+        result = subprocess.run(
+            [sys.executable, str(PATCHER), "--executable", str(executable), "--bundle-type", "nsis"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return result, executable, executable.read_bytes()
+
+    def test_replaces_the_one_official_tauri_token_byte_for_byte(self) -> None:
+        original = b"prefix\x00" + UNKNOWN + b"\x00suffix"
+
+        result, _, patched = self.run_patcher(original)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(patched, original.replace(UNKNOWN, NSIS))
+        self.assertEqual(len(patched), len(original))
+
+    def test_missing_token_is_fail_closed_and_leaves_the_binary_unchanged(self) -> None:
+        original = b"not-a-tauri-binary"
+
+        result, _, patched = self.run_patcher(original)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected exactly one", result.stderr)
+        self.assertEqual(patched, original)
+
+    def test_duplicate_token_is_fail_closed_and_leaves_the_binary_unchanged(self) -> None:
+        original = UNKNOWN + b"middle" + UNKNOWN
+
+        result, _, patched = self.run_patcher(original)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected exactly one", result.stderr)
+        self.assertEqual(patched, original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -97,6 +97,21 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("Get-FileHash", windows)
         self.assertIn("CYS_WINDOWS_GUI_SHA256", windows)
         self.assertIn("Unsigned Windows GUI hash drifted during Tauri build", windows)
+        compile_gui = "bunx '@tauri-apps/cli@2' build --no-bundle"
+        patch_gui = "python scripts/patch-tauri-bundle-type.py"
+        bundle_gui = "bunx '@tauri-apps/cli@2' bundle --bundles nsis"
+        self.assertEqual(windows.count(compile_gui), 1)
+        self.assertEqual(windows.count(patch_gui), 1)
+        self.assertEqual(windows.count(bundle_gui), 1)
+        compiled_gui = windows.index(compile_gui)
+        patched_gui = windows.index(patch_gui)
+        measured_hash = windows.index("$guiHash =")
+        pinned_hash = windows.index("$env:CYS_WINDOWS_GUI_SHA256 = $guiHash")
+        release_bundle = windows.index(bundle_gui)
+        self.assertLess(compiled_gui, patched_gui)
+        self.assertLess(patched_gui, measured_hash)
+        self.assertLess(measured_hash, pinned_hash)
+        self.assertLess(pinned_hash, release_bundle)
         self.assertNotIn("windows-authenticode.ps1", windows)
         self.assertNotIn("certificateThumbprint", windows)
 
@@ -200,7 +215,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("runtime-stage-sign-windows.ps1", windows)
         self.assertLess(
             windows.index("browser-runtime-metadata.py prepare"),
-            windows.index("cargo build --locked --release --target"),
+            windows.index("bunx '@tauri-apps/cli@2' build --no-bundle"),
         )
         for required in ("codesign --force", "--timestamp", "--options runtime", "codesign --verify"):
             self.assertIn(required, mac_sign)


### PR DESCRIPTION
## Summary

- compile the Windows GUI with Tauri's exact release feature set before hashing
- apply Tauri's official NSIS bundle marker before pinning the GUI digest in cysd
- bundle the already-built GUI without a second app compile, retaining the final drift hard-gate
- fail closed on missing or duplicate Tauri markers with dynamic regression coverage

## Verification

- 60 release unit/static tests
- PowerShell parser
- Python compile check
- actionlint
- diff check
- secret/PII scan across 744 tracked files

## Failure evidence addressed

The prior v0.13.2 candidate produced NSIS successfully and then stopped with `Unsigned Windows GUI hash drifted during Tauri build`. Tauri compiles with release-only features and patches the NSIS copy with a bundle marker, so hashing a plain Cargo build did not represent the installed GUI bytes.
