### PR TITLE
test(release): use an approved home placeholder

### DIFF
--- a/cysjavis-pack/browserd/tests/unit.test.ts
+++ b/cysjavis-pack/browserd/tests/unit.test.ts
@@ -57,12 +57,12 @@ test("UNTRUSTED_HEADER: 지시 무시 문구 포함", () => {
 });
 
 test("strict packaged engine stores endpoint only under supervisor-owned root", () => {
-  expect(resolveBrowserRoot("/home/user", "/private/engine", "1")).toBe("/private/engine");
-  expect(resolveBrowserRoot("/home/user", "/private/engine", "0")).toBe(
-    join("/home/user", ".cys", "browser"),
+  expect(resolveBrowserRoot("/home/you", "/private/engine", "1")).toBe("/private/engine");
+  expect(resolveBrowserRoot("/home/you", "/private/engine", "0")).toBe(
+    join("/home/you", ".cys", "browser"),
   );
-  expect(resolveBrowserRoot("/home/user", undefined, "1")).toBe(
-    join("/home/user", ".cys", "browser"),
+  expect(resolveBrowserRoot("/home/you", undefined, "1")).toBe(
+    join("/home/you", ".cys", "browser"),
   );
 });
 


### PR DESCRIPTION
## Summary

- replace the browser unit test's generic home fixture with the release scanner's approved placeholder
- retain the fail-closed real-home-path rule unchanged

## Failure evidence addressed

The successful platform build run stopped in pack-artifacts because five `/home/user` test-fixture occurrences were classified as personal home paths.

## Verification

- pack secret scanner: OK
- whole-repository secret/PII scan: 746 tracked files clean
- browserd unit test: 12 passed
- diff check
