### PR TITLE
fix(release): suppress macOS handoff sidecars

### DIFF
--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -39,7 +39,7 @@ case "$MODE" in
     mkdir -p "$(dirname "$OUTPUT")"
     PARTIAL="${OUTPUT}.partial.$$"
     trap 'rm -f "$PARTIAL"' EXIT
-    tar -C "$INPUT_DIR" -czf - . | openssl enc -aes-256-cbc -salt \
+    COPYFILE_DISABLE=1 tar -C "$INPUT_DIR" -czf - . | openssl enc -aes-256-cbc -salt \
       -pbkdf2 -iter 200000 -md sha256 -pass env:RELEASE_HANDOFF_KEY \
       -out "$PARTIAL"
     [ -s "$PARTIAL" ] || { echo "encrypted handoff is empty" >&2; exit 1; }

--- a/scripts/tests/test_release_handoff.py
+++ b/scripts/tests/test_release_handoff.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -43,6 +44,35 @@ class ReleaseHandoffTests(unittest.TestCase):
             (self.unpacked / "candidate.bin").read_bytes(),
             b"signed-release-candidate",
         )
+
+    def test_pack_disables_macos_copyfile_sidecars(self) -> None:
+        real_tar = shutil.which("tar")
+        self.assertIsNotNone(real_tar)
+        wrapper_dir = self.work / "bin"
+        wrapper_dir.mkdir()
+        wrapper = wrapper_dir / "tar"
+        wrapper.write_text(
+            "#!/bin/sh\n"
+            "[ \"${COPYFILE_DISABLE:-}\" = 1 ] || { "
+            "echo 'COPYFILE_DISABLE was not set' >&2; exit 97; }\n"
+            "exec \"$CYS_REAL_TAR\" \"$@\"\n",
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+        result = subprocess.run(
+            ["bash", str(HANDOFF), "pack", str(self.source), str(self.encrypted)],
+            cwd=ROOT,
+            env={
+                **os.environ,
+                "PATH": f"{wrapper_dir}{os.pathsep}{os.environ['PATH']}",
+                "CYS_REAL_TAR": str(real_tar),
+                "RELEASE_HANDOFF_KEY": "x" * 48,
+            },
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_missing_short_or_wrong_key_fails_closed(self) -> None:
         missing = subprocess.run(


### PR DESCRIPTION
## Summary

- set `COPYFILE_DISABLE=1` on confidential handoff tar creation so macOS does not emit AppleDouble sidecars
- dynamically verify the tar subprocess receives the fail-safe environment setting
- retain the exact asset-set assembler gate unchanged

## Failure evidence addressed

The successful platform and pack run stopped during assembly because Linux extraction found `._cys_0.13.2_aarch64.dmg` and `._cys_0.13.2_x64.dmg` in macOS-created handoffs.

## Verification

- handoff tests: 3 passed
- full release test suite: 61 passed
- ShellCheck and actionlint
- secret/PII scan: 746 tracked files clean
- locally downloaded and CRC-checked all four successful encrypted CI handoffs
- local exact assembly: 14 release files, 13 checksum rows, missing 0
- all 13 SHA-256 rows verified
- Defender and recovery markers verified in the generated homepage snapshot
