### PR TITLE
Fix mouse wheel scroll, click-to-focus jump, drag-select, and Ctrl+C copy

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1627,6 +1627,10 @@ async function makePane(sid: number, title: string, socket?: string): Promise<Pa
       // 위로 스크롤 = 즉시 해제 — rAF 판정까지 기다리면 스트리밍 중 write 스냅이 먼저 끌어내려
       // 사용자가 위로 못 올라가는 경주가 생긴다. 실제 위치 판정은 xterm이 휠을 처리한 뒤(rAF).
       if (e.deltaY < 0) follow = false;
+      // ★2026-08-11: WebView2 환경에서 xterm 자체의 마우스휠→스크롤 리포팅(coreMouseService)이
+      // 동작하지 않는 문제의 우회 — PTY 왕복 없이 로컬 뷰포트만 직접 넘긴다(scrollLines는
+      // 스크롤백 탐색일 뿐 PTY로 아무것도 보내지 않으므로 앱의 마우스트래킹 모드와 무관하게 항상 동작).
+      term.scrollLines(e.deltaY > 0 ? 3 : -3);
       requestAnimationFrame(() => {
         follow = atBottom();
       });
@@ -1930,7 +1934,19 @@ function setFocus(sid: number) {
   focusedSid = sid;
   const key = paneKey(sid, current()?.socket);
   for (const [id, rt] of panes) rt.el.classList.toggle("focused", id === key);
-  panes.get(key)?.term.focus();
+  // ★2026-08-11: term.focus() → 내부 textarea.focus()의 브라우저 기본 동작(scroll-into-view)이
+  // 스크롤백을 보던 중이어도 뷰포트를 강제로 바닥(커서 위치)까지 끌어내린다 — 클릭 한 번에
+  // 이전 기록을 볼 수 없게 되는 원인. 포커스 전 뷰포트 위치를 기억했다가 그대로 복원한다.
+  const rt = panes.get(key);
+  if (rt) {
+    const buf = rt.term.buffer.active;
+    const savedViewportY = buf.viewportY;
+    const wasAtBottom = buf.viewportY >= buf.baseY;
+    rt.term.focus();
+    if (!wasAtBottom) {
+      requestAnimationFrame(() => rt.term.scrollToLine(savedViewportY));
+    }
+  }
   updateFtRoot(); // 파일 트리가 열려 있으면 선택한 surface의 폴더로 전환
 }
 

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,6 +1,26 @@
 // cys UI — xterm.js panes over the cysd socket (thin client).
 // 세션 영속은 구조로 해결: 세션(PTY)은 데몬 소유, UI는 attach만 한다.
 
+// ★2026-08-11: 이 WebView2 환경에서 xterm의 coreMouseService(마우스트래킹 리포팅)가 제대로
+// 동작하지 않아 앱(claude.exe 등)이 마우스트래킹을 요청(DECSET ?1000/1002/1003/1006 등)하는
+// 순간부터 xterm의 selectionService가 비활성화되고 드래그선택·Ctrl+C복사·클릭 동작이 전부
+// 불안정해진다(Shift로 강제선택은 우회되지만 그 경우도 xterm 자신의 selection이 아닌 브라우저
+// 네이티브 selection이라 Ctrl+C 복사가 안 걸린다). 애초에 이 앱들은 마우스트래킹을 실질적으로
+// 쓰지 않으므로(휠 스크롤은 별도로 scrollLines 직접호출로 이미 우회함), PTY 출력에서 마우스트래킹
+// 활성화 시퀀스 자체를 걸러내 xterm이 항상 "마우스트래킹 꺼짐" 상태로 selectionService의 정상
+// (그리고 이미 잘 검증된) 코드 경로만 타게 만든다. 바이트 단위로만 다뤄 UTF-8 내용은 손상 없음
+// (latin1 1:1 매핑 왕복 — 조각난 멀티바이트 청크 경계에서도 안전).
+const MOUSE_TRACKING_DECSET_RE = /\x1b\[\?(?:1000|1001|1002|1003|1004|1005|1006|1015|1016)[hl]/g;
+function stripMouseTracking(bytes: Uint8Array): Uint8Array {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  if (!/\x1b\[\?1\d{3}[hl]/.test(s)) return bytes; // 흔한 경로(마우스트래킹 시퀀스 없음) 빠른 반환
+  s = s.replace(MOUSE_TRACKING_DECSET_RE, "");
+  const out = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+  return out;
+}
+
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { isPermissionGranted, requestPermission, sendNotification } from "@tauri-apps/plugin-notification";
@@ -1646,6 +1666,24 @@ async function makePane(sid: number, title: string, socket?: string): Promise<Pa
     // 브라우저 네이티브 paste 이벤트가 발화되고 아래 paste 리스너가 클립보드를 PTY로 보낸다.
     // (WebView2에서 xterm 기본 붙여넣기가 안 먹던 문제 — permission 불요의 clipboardData 경로.)
     if ((e.ctrlKey || e.metaKey) && (e.key === "v" || e.key === "V")) return false;
+    // ★복사(Ctrl/Cmd+C): 실제 선택된 텍스트가 있을 때만(hasSelection()은 폭 0인 선택에도
+    // true를 반환하므로 getSelection() 길이로 판정 — reviewer-claude-1 지적) 클립보드로만
+    // 복사하게 false 반환 — 브라우저 네이티브 copy를 막고 직접 writeText한다. writeText는
+    // 비동기라 return false 시점엔 성공 여부를 알 수 없으므로, 실패하면(예: WebView2 권한
+    // 문제 — 이 앱의 붙여넣기가 겪었던 것과 같은 부류) fail-open으로 인터럽트 바이트(\x03)를
+    // 뒤늦게라도 PTY로 보내 "복사도 인터럽트도 둘 다 조용히 실패"를 막는다(reviewer-claude-1 지적).
+    // 선택이 없으면 true를 반환해 기존 동작(Ctrl+C=인터럽트 전송)을 그대로 보존.
+    if ((e.ctrlKey || e.metaKey) && (e.key === "c" || e.key === "C") && e.type === "keydown") {
+      const selText = term.getSelection();
+      if (selText.length > 0) {
+        navigator.clipboard.writeText(selText).catch((err) => {
+          console.error("clipboard writeText 실패 — fail-open으로 인터럽트 전송", err);
+          sendRaw("\x03");
+        });
+        return false;
+      }
+      return true;
+    }
     // ★Shift+Enter = 줄바꿈(오너 요청 2026-07-12): Option/Alt+Enter가 보내는 것과 동일한
     // 바이트(ESC+CR)를 PTY로 전송 — claude 등 CLI가 meta-Enter로 해석해 프롬프트에 개행 삽입.
     // mac·Windows 공통(플랫폼 분기 불요). keydown에서만 전송하고 keypress/keyup은 흡수해 이중 전송 방지.
@@ -1806,7 +1844,7 @@ async function makePane(sid: number, title: string, socket?: string): Promise<Pa
     exited_event: string;
   };
   const un1 = await listen(ev.output_event, (e) => {
-    term.write(b64ToBytes(e.payload as string), snapToBottom);
+    term.write(stripMouseTracking(b64ToBytes(e.payload as string)), snapToBottom);
   });
   const un2 = await listen(ev.exited_event, () => {
     term.write("\r\n\x1b[31m[surface exited]\x1b[0m\r\n", snapToBottom);

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1622,7 +1622,9 @@ async function makePane(sid: number, title: string, socket?: string): Promise<Pa
     fontSize,
     // 배경 테마: 하드코딩 리터럴 대신 현재 색 상태 참조 — 새 pane도 커스텀 색으로 생성된다.
     theme: { background: currentBg(), foreground: readableForeground(currentBg()) },
-    scrollback: 5000,
+    // 5000줄은 며칠씩 상주하는 에이전트 pane(각성 핑·지침 재주입 반복)에서 반나절 안에 꽉 차
+    // 오래된 줄이 물리적으로 버려진다 — "스크롤이 일정 화면까지만 올라가고 멈춘다"의 실제 원인.
+    scrollback: 100000,
   });
   const fit = new FitAddon();
   term.loadAddon(fit);


### PR DESCRIPTION
## Summary
- Fix mouse wheel scroll not working in terminal panes (coreMouseService bypass — strip mouse-tracking DECSET sequences before xterm sees them, call `scrollLines` directly on wheel events).
- Fix clicking a pane snapping the viewport to the bottom (save/restore scroll position around `term.focus()`).
- Fix drag-to-select requiring Shift (same coreMouseService bypass extended to drag).
- Add Ctrl+C clipboard copy of the current selection (falls back to sending the interrupt byte when there's no selection or clipboard write fails).
- Increase terminal scrollback buffer from 5000 to 100000 lines — long-running panes (agent sessions that stay up for days) fill 5000 lines within hours and start silently discarding history.

## Root cause
xterm.js's `coreMouseService` doesn't behave reliably in this Tauri/WebView2 environment. When a PTY app requests mouse tracking, xterm disables its own native selection handling, breaking wheel scroll and drag-select. Rather than fix coreMouseService internals, this PR strips the mouse-tracking enable/disable escape sequences before they reach xterm, so xterm never leaves its default (working) mouse mode.

## Test plan
- [x] Built as a debug binary (matches production deployment profile), side-by-side smoke tested before replacing the installed binary.
- [x] Two independent reviewer passes (wheel/click/drag/clipboard fixes) — both ACCEPT after line-by-line diff review.
- [x] Scrollback change independently reviewed — ACCEPT, confirmed as isolated one-line config change with no logic regression.
- [x] Deployed to production, verified via SHA256 hash match and live relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)