### PR TITLE
fix(cysjavis-pack): guard cys-dept new-surface against main-pack wipe on dead-socket autostart

### DIFF
--- a/cysjavis-pack/bin/cys-dept
+++ b/cysjavis-pack/bin/cys-dept
@@ -531,7 +531,11 @@ PY
       echo "[cys-dept] $name CYS_DEPT_NO_MASTER=1 — 셸 미생성(빈 데몬)" >&2
     elif dept_has_master "$sock"; then
       echo "[cys-dept] $name 이미 master surface 존재 — 셸 생성 생략(멱등)" >&2
-    elif CYS_SOCKET="$sock" "$CYS" new-surface --socket "$sock" --role master --cwd "${CYS_DEPT_CWD:-$HOME}" >/dev/null 2>&1; then
+    #   ★팩소실 방어(2026-08-08 실험확정): 무가드 new-surface 가 죽은 소켓을 만나면 cysd 를 autostart 하고,
+    #   그 데몬이 기동하며 CYS_PACK_DIR 에 팩을 통째 재설치한다(pack→pack.prev 리네임+벤더 설치, 수십 초).
+    #   여기서 CYS_PACK_DIR 를 안 주면 호출자값(=메인 팩)을 상속해 메인 팩이 원복/소거된다.
+    #   위 ready "$sock" 가 데몬 up 을 이미 보증하므로 autostart 는 원래 불필요 — 가드+스코프 이중 차단.
+    elif CYS_NO_AUTOSTART=1 CYS_SOCKET="$sock" CYS_PACK_DIR="$pack" "$CYS" new-surface --socket "$sock" --role master --cwd "${CYS_DEPT_CWD:-$HOME}" >/dev/null 2>&1; then
       echo "[cys-dept] $name role=master 빈 셸 생성 완료 — 사용자가 직접 claude 연결 (cwd=${CYS_DEPT_CWD:-$HOME})" >&2
     else
       echo "[cys-dept] WARN: $name 셸 생성 실패 — read-screen 점검(데몬·격리는 정상)" >&2
@@ -670,7 +674,10 @@ PY
     # ★더블master guard(부트↔수동선언 경합 좀비 방지): 이미 live master surface가 있으면 셸 생성 생략(멱등).
     if dept_has_master "$sock"; then
       echo "[cys-dept] $name 이미 live master surface 존재 — 셸 생성 생략(멱등 더블master 방지)" >&2
-    elif CYS_SOCKET="$sock" "$CYS" new-surface --socket "$sock" --role master --cwd "$cwd" >/dev/null 2>&1; then
+    #   ★팩소실 방어(2026-08-08 실험확정 · 위 allocate 케이스와 동일 기제): 무가드 new-surface → cysd autostart →
+    #   상속된 CYS_PACK_DIR(=메인 팩)에 팩 통째 재설치. 위 ready "$sock" 가 데몬 up 을 보증하므로
+    #   autostart 는 불필요 — 가드로 차단하고, 만에 하나 떠도 부서 팩으로만 향하게 스코프한다.
+    elif CYS_NO_AUTOSTART=1 CYS_SOCKET="$sock" CYS_PACK_DIR="$pack" "$CYS" new-surface --socket "$sock" --role master --cwd "$cwd" >/dev/null 2>&1; then
       echo "[cys-dept] $name role=master 빈 셸 생성 완료 — 사용자가 직접 claude 연결 (미션 파일: $MISS/$key.md)" >&2
     else
       echo "[cys-dept] WARN: $name 셸 생성 실패 — read-screen 점검(데몬·격리는 정상)" >&2


### PR DESCRIPTION
## Root cause
`cys-dept`'s two "spawn empty master shell" call sites (`allocate` and `create` paths) invoke `cys new-surface` without scoping `CYS_SOCKET`'s matching `CYS_PACK_DIR` or disabling autostart. When the target socket is dead (fresh department boot, or any department whose daemon has exited from being idle), `new-surface` triggers `cysd`'s autostart path. That autostart re-installs a full pack at whatever `CYS_PACK_DIR` is in the **caller's** environment — and `cys-dept`'s caller almost always has the main pack's `CYS_PACK_DIR` (or none, which also resolves to the main pack). Result: launching/reactivating a department can silently wipe and reinstall the main `~/.cys/pack` (renamed to `pack.prev`, vendor pack reinstalled fresh). If the reinstall is interrupted mid-way, `pack.prev` holds the old data but the live pack is left empty — we hit this in production as a full main-pack data-loss incident.

The preceding `ready "$sock"` check already guarantees the daemon for this department is up before we reach the `new-surface` call, so autostart is never actually needed here — it's pure incidental risk with no functional purpose.

## Reproduction (isolated, no data loss)
1. Point `CYS_PACK_DIR` at a scratch directory with a live, populated pack.
2. Kill/never-start the daemon for a given `CYS_SOCKET` (simulating a dead department socket or fresh boot).
3. Call `cys new-surface --socket "$sock" --role master ...` without `CYS_NO_AUTOSTART` / `CYS_PACK_DIR` scoping, inheriting the caller's `CYS_PACK_DIR` (the "main" pack in this repro).
4. Observe: `[cys] cysd not running — autostarting cysd.exe`, followed by a full reinstall of the main pack directory (renamed to `pack.prev`, fresh vendor pack written in its place) — takes on the order of 10s of seconds, confirmed via file count going 0 → N mid-install.
5. Control: same steps with `CYS_NO_AUTOSTART=1` set — autostart is refused immediately (os error 2), zero files touched, main pack mtime unchanged.

## Fix
Scope both `new-surface` call sites (allocate + create paths) with `CYS_NO_AUTOSTART=1 CYS_PACK_DIR="$pack"` (the department's own pack dir, already resolved earlier in each code path). This double-guards: autostart is refused outright, and even if a future code path allowed it through, `CYS_PACK_DIR` now points at the department's own pack instead of whatever the caller happened to have set — so the main pack can never be touched by this call site again.

## Verification
- `bash -n cysjavis-pack/bin/cys-dept` — syntax check passes.
- Confirmed both call sites now carry the guard.
- Re-ran the isolated repro above against the patched script: dead-socket `new-surface` now fails closed instead of triggering autostart; main pack untouched (file count / mtime unchanged) across repeated triggers.
- This exact patch (as a local override, since the installed pack self-heals from the vendor copy embedded in `cysd` on every reinstall) has been running in production since 2026-08-08 and has been re-applied after three observed vendor-drift reversions (2026-08-08, 2026-08-09, 2026-08-14) with zero regressions and zero further pack-wipe recurrences while active.

## Scope note
This only touches the two `new-surface` invocations inside `cys-dept` (bash script in `cysjavis-pack/`). No changes to the Rust core / cys-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)