### PR TITLE
ci: PR에 도는 검사 신설 — 셸·파이썬 문법 게이트 (현재 pull_request 트리거 워크플로우 0개)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,88 @@
+name: pr-check
+
+# ★왜 이 파일이 필요한가 (2026-08-22)
+#   이 레포에는 `pull_request` 로 트리거되는 워크플로우가 하나도 없었다. main 의 워크플로우
+#   4개는 각각 tags(v*/pack-v*) · workflow_dispatch · 특정 feat 브랜치 push 로만 돈다.
+#   실제 검증 레인인 ci-branch.yml 은 main 에 없고, 있는 브랜치에서도 트리거가
+#   `push: branches: ['feat/**']` 뿐이다. 그 결과 외부 기여 PR 은 자동 검증을 한 줄도
+#   받지 못한 채 사람 손으로만 확인해야 했다(열린 PR 4건 실측).
+#
+# ★왜 ci-branch.yml 을 main 에 올리는 방식이 아닌가
+#   ci-branch.yml(591줄)은 아직 main 에 없는 소스를 검사한다 — src/todo_scan.rs ·
+#   cysjavis-pack/bin/tests/test_todo_decl.py · scripts/gen_ceo_template.py ·
+#   cysjavis-pack/bin/javis_detect.py 등. 그대로 main 에 올리면 첫 실행부터 빨간다.
+#   그래서 이 파일은 그 레인을 대체하지 않는다. **main 트리에서 지금 확실히 통과하는
+#   검사만** 담은 얇은 게이트다. 컴파일·bun·크로스플랫폼 파리티 같은 무거운 레인은
+#   ci-branch.yml 의 몫으로 남긴다 — 그 레인이 main 에 랜딩되면 이 파일은 흡수되어도 된다.
+#
+# ★검증(2026-08-22, main=721bc99): 아래 두 검사를 main 과 열린 PR 4건(#10·#35·#42·#43)
+#   에서 각각 실행해 전부 통과를 확인했다. 셸 14개 · 파이썬 119개.
+
+on:
+  pull_request:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# fork PR 은 브랜치명이 흔히 겹치므로(main·patch-1) head 저장소까지 키에 넣는다 —
+# 브랜치명만 쓰면 서로 다른 두 PR 이 상대의 실행을 취소한다.
+concurrency:
+  group: pr-check-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  syntax:
+    name: 문법 검사 (셸 · 파이썬)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      # shebang 이 bash/sh 인 파일만 고른다 — 목록을 손으로 유지하지 않으므로
+      # 새 스크립트가 추가돼도 이 워크플로우를 고칠 필요가 없다.
+      - name: bash -n — 셸 스크립트 문법
+        run: |
+          set -uo pipefail
+          fail=0
+          found=0
+          while IFS= read -r f; do
+            found=$((found + 1))
+            if err="$(bash -n "$f" 2>&1)"; then
+              echo "  OK   $f"
+            else
+              echo "::error file=$f::셸 문법 오류"
+              printf '%s\n' "$err" | sed 's/^/       /'
+              fail=1
+            fi
+          done < <(find cysjavis-pack/bin scripts -maxdepth 2 -type f \
+                     -exec sh -c 'head -1 "$1" | grep -q "^#!.*\(bash\|sh\)"' _ {} \; -print)
+          echo "검사한 셸 스크립트: ${found}개"
+          # 대상이 0개면 find 패턴이 깨졌다는 뜻 — 조용한 통과(위양성 초록)를 막는다.
+          if [ "$found" -eq 0 ]; then
+            echo "::error::셸 스크립트를 하나도 찾지 못했다 — 경로 패턴 점검 필요"
+            fail=1
+          fi
+          exit "$fail"
+
+      - name: py_compile — 파이썬 문법
+        run: |
+          set -uo pipefail
+          fail=0
+          found=0
+          while IFS= read -r f; do
+            found=$((found + 1))
+            if err="$(python3 -m py_compile "$f" 2>&1)"; then
+              :
+            else
+              echo "::error file=$f::파이썬 문법 오류"
+              printf '%s\n' "$err" | sed 's/^/       /'
+              fail=1
+            fi
+          done < <(find cysjavis-pack -name '*.py' -type f)
+          echo "검사한 파이썬 파일: ${found}개"
+          if [ "$found" -eq 0 ]; then
+            echo "::error::파이썬 파일을 하나도 찾지 못했다 — 경로 패턴 점검 필요"
+            fail=1
+          fi
+          exit "$fail"


### PR DESCRIPTION
## 무엇을 하는 PR인가

`pull_request` 로 트리거되는 워크플로우를 신설합니다. 셸 스크립트 문법(`bash -n`)과
파이썬 문법(`py_compile`)만 검사하는 얇은 게이트입니다.

## 왜 필요한가

현재 이 레포에는 **`pull_request` 트리거 워크플로우가 하나도 없습니다.**

| 워크플로우 (main) | 트리거 |
|---|---|
| `release.yml` | `push: tags: v*` · `workflow_dispatch` |
| `pack-release.yml` | `push: tags: pack-v*` |
| `release-publish.yml` | `workflow_dispatch` |
| `windows-build.yml` | `push: branches: ['feat/windows-x64-dist']` |

실제 검증 레인인 `ci-branch.yml` 은 `main` 에 존재하지 않고, 있는 브랜치에서도 트리거가
`push: branches: ['feat/**']` 뿐입니다. 그래서 외부 기여 PR 은 자동 검증을 한 줄도 받지
못합니다 — 현재 열린 PR 4건(#10 · #35 · #42 · #43) 모두 체크 결과가 0건입니다.

`ci-branch.yml` 주석에 적혀 있는 대로 *"로컬 맥에 cargo·bun 부재 → 이 워크플로우가 유일한
컴파일·bun·크로스플랫폼 파리티 검증 경로"* 라면, 그 경로가 PR에서 안 도는 것은 리뷰 부담을
전부 사람에게 남깁니다.

## 왜 `ci-branch.yml` 을 main 에 올리는 방식이 아닌가

그 파일(591줄)은 아직 `main` 에 없는 소스를 검사합니다:

- `src/todo_scan.rs`
- `cysjavis-pack/bin/tests/test_todo_decl.py`
- `cysjavis-pack/bin/tests/parity_todo_scan.py`
- `scripts/gen_ceo_template.py`
- `cysjavis-pack/bin/javis_detect.py`

그대로 올리면 첫 실행부터 실패합니다. 그래서 이 PR 은 그 레인을 **대체하지 않습니다.**
`main` 트리에서 지금 확실히 통과하는 검사만 담았고, 컴파일·bun·크로스플랫폼 파리티는
`ci-branch.yml` 의 몫으로 남겨 두었습니다. 그 레인이 `main` 에 랜딩되면 이 파일은 흡수되어도
무방합니다.

## 변경 내용

- 셸: shebang 이 `bash`/`sh` 인 파일에 `bash -n` (문법 검사만 — **실행하지 않습니다**)
- 파이썬: 모든 `.py` 에 `python3 -m py_compile`
- 대상 파일이 0개면 실패 처리 — 경로 패턴이 깨졌을 때 조용히 초록이 되는 것을 막습니다
- 파일 목록을 손으로 유지하지 않으므로 새 스크립트가 추가돼도 이 워크플로우를 고칠 필요가 없습니다
- fork PR 은 브랜치명이 흔히 겹치므로(`main`·`patch-1`) `concurrency` 키에 head 저장소를 포함했습니다
- `actions/checkout` 은 `ci-branch.yml` 과 **동일한 SHA** 로 핀했습니다

## 검증 방법

`main`(721bc99)과 열린 PR 4건의 head 를 각각 체크아웃해 두 검사를 실행했습니다.

| 대상 | 셸 | 파이썬 | 결과 |
|---|---|---|---|
| `main` | 14개 | 119개 | 통과 |
| #10 | 14개 | 119개 | 통과 |
| #35 | 14개 | 119개 | 통과 |
| #42 | 14개 | 119개 | 통과 |
| #43 | 14개 | 119개 | 통과 |

음성 대조도 했습니다 — 일부러 문법이 깨진 셸/파이썬 파일을 넣으면 `::error` 를 내고
exit 1 로 실패합니다. GitHub 러너와 같은 셸 옵션(`bash --noprofile --norc -e -o pipefail`)으로
스텝 본문을 그대로 실행해 확인했습니다.

실행 시간은 체크아웃 포함 1분 미만입니다.

## 이후 제안 (이 PR 범위 밖)

`ci-branch.yml` 을 `main` 에 랜딩하고 `pull_request` 를 트리거에 추가하는 것이 근본 해법입니다.
그때 이 워크플로우는 삭제하셔도 됩니다. 다만 그 랜딩은 아직 머지되지 않은 소스들과 함께
가야 하므로 메인테이너 판단이 필요하다고 보고, 이 PR 은 그 판단과 무관하게 지금 당장
동작하는 최소 게이트만 제안합니다.
